### PR TITLE
OS X ~/Library change

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
@@ -546,7 +546,7 @@ final public class AndrolibResources {
         /* store in user-home, for Mac OS X */
         if (System.getProperty("os.name").equals("Mac OS X")) {
            path = System.getProperty("user.home") + File.separatorChar +
-                "Library/Application Support/apktool/framework"; }
+                "Library/apktool/framework"; }
         else {
             path = System.getProperty("user.home") + File.separatorChar +	
                 "apktool" + File.separatorChar + "framework";


### PR DESCRIPTION
...esolution is to change the ~/Library/Application Support/apktool path to ~/Library/apktool. Fix is for OS X only. Do not think there is problems on other platforms with this.
