### PR TITLE
Support for --framework <dir> command line argument to specify the location of the framework files

### DIFF
--- a/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
+++ b/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
@@ -111,7 +111,11 @@ public class Main {
                 decoder.setDecodeResources(ApkDecoder.DECODE_RESOURCES_NONE);
             } else if ("--keep-broken-res".equals(opt)) {
                 decoder.setKeepBrokenResources(true);
-            } else {
+            } else if ("--framework".equals(opt)) {
+                i++;
+                System.out.println("Using Framework Directory: " + args[i]);
+                decoder.setFrameworkDir(args[i]);
+	    } else {
                 throw new InvalidArgsError();
             }
         }
@@ -262,6 +266,8 @@ public class Main {
             "            Force delete destination directory.\n" +
             "        -t <tag>, --frame-tag <tag>\n" +
             "            Try to use framework files tagged by <tag>.\n" +
+            "           --framework <dir>\n" +
+            "            Use the specified directory for framework files" +            
             "        --keep-broken-res\n" +
             "            Use if there was an error and some resources were dropped, e.g.:\n" +
             "            \"Invalid config flags detected. Dropping resources\", but you\n" +

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
@@ -157,6 +157,10 @@ public class ApkDecoder {
     public void setKeepBrokenResources(boolean keepBrokenResources) {
         mKeepBrokenResources = keepBrokenResources;
     }
+       
+    public void setFrameworkDir(String dir) {
+       mFrameworkDir = dir;    
+    }
 
     public ResTable getResTable() throws AndrolibException {
         if (mResTable == null) {
@@ -167,6 +171,7 @@ public class ApkDecoder {
                     "Apk doesn't contain either AndroidManifest.xml file or resources.arsc file");
             }
             AndrolibResources.sKeepBroken = mKeepBrokenResources;
+            AndrolibResources.sFrameworkFolder = mFrameworkDir;
             mResTable = mAndrolib.getResTable(mApkFile, hasResources);
             mResTable.setFrameTag(mFrameTag);
         }
@@ -271,5 +276,6 @@ public class ApkDecoder {
     private boolean mForceDelete = false;
     private String mFrameTag;
     private boolean mKeepBrokenResources = false;
+    private String mFrameworkDir = null;
     private boolean mBakDeb = true;
 }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
@@ -545,8 +545,11 @@ final public class AndrolibResources {
     private File getFrameworkDir() throws AndrolibException {
         String path;
         
-        /* store in user-home, for Mac OS X */
-        if (System.getProperty("os.name").equals("Mac OS X")) {
+        /* if a framework path was specified on the command line, use it */
+        if (sFrameworkFolder != null) {
+	   path = sFrameworkFolder;        	  
+        } else if (System.getProperty("os.name").equals("Mac OS X")) {
+            /* store in user-home, for Mac OS X */
            path = System.getProperty("user.home") + File.separatorChar +
                 "Library/apktool/framework"; }
         else {
@@ -556,6 +559,9 @@ final public class AndrolibResources {
         File dir = new File(path);
         if (! dir.exists()) {
             if (! dir.mkdirs()) {
+		if (sFrameworkFolder != null) {
+		    System.out.println("Can't create Framework directory: " + dir);
+                }
                 throw new AndrolibException("Can't create directory: " + dir);
             }
         }
@@ -573,7 +579,7 @@ final public class AndrolibResources {
 
     // TODO: dirty static hack. I have to refactor decoding mechanisms.
     public static boolean sKeepBroken = false;
-
+    public static String sFrameworkFolder = null;
 
     private final static Logger LOGGER =
         Logger.getLogger(AndrolibResources.class.getName());


### PR DESCRIPTION
Support for "--framework < dir >" command line argument to specify the location of the framework files (previously forced you to keep them in the home folder)

I need this for a PHP website I wrote, I want to keep the jar and framework files inside of my existing website source tree

Right now, you have to install the framework files in the home folder, which isn't available if you are running this from inside a webserver.
