### PR TITLE
Fix for Null Reference while extracting Resources.

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
@@ -319,9 +319,13 @@ public class ARSCDecoder {
 			mPkg.addResSpec(spec);
 			mType.addResSpec(spec);
 
+			if (mConfig == null) {
+			    mConfig = mPkg.getOrCreateConfig(new ResConfigFlags());
+			}
+
 			ResValue value = new ResBoolValue(false, null);
-			ResResource res = new ResResource(
-					mPkg.getOrCreateConfig(new ResConfigFlags()), spec, value);
+			ResResource res = new ResResource(mConfig, spec, value);
+
 			mPkg.addResource(res);
 			mConfig.addResource(res);
 			spec.addResource(res);


### PR DESCRIPTION
I was getting a Null Reference exception on "mConfig.addResource(res);" since for my target apk, that point was reached before mConfig was ever initialized. 

Since "res" was already initialized with "mPkg.getOrCreateConfig(new ResConfigFlags())", it seems ok to just initialize mConfig here to that if it's null at this point.

I'm not very familiar with the code, so let me know if thats not the proper way of fixing it. 

Thank you.
