### PR TITLE
Minor fix to avoid crashing due to trailing ";".

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
@@ -187,7 +187,7 @@ public class StringBlock {
 			builder.append(tag.substring(0, pos));
 			if (!close) {
 				boolean loop = true;
-				while (loop) {
+				while (loop && pos+1<tag.length()) {
 					int pos2 = tag.indexOf('=', pos + 1);
 					builder.append(' ').append(tag.substring(pos + 1, pos2))
 							.append("=\"");


### PR DESCRIPTION
Minor fix to avoid crashing due to trailing ";" in style lines. In the command line, the user sees:

$ apktool d app.apk 
I: Baksmaling...
I: Loading resource table...
Exception in thread "main" java.lang.StringIndexOutOfBoundsException: String index out of range: -80
    at java.lang.String.substring(String.java:1911)
    at brut.androlib.res.decoder.StringBlock.outputStyleTag(StringBlock.java:193)
    at brut.androlib.res.decoder.StringBlock.getHTML(StringBlock.java:170)
    at brut.androlib.res.decoder.ARSCDecoder.readValue(ARSCDecoder.java:224)
    at brut.androlib.res.decoder.ARSCDecoder.readEntry(ARSCDecoder.java:179)
    at brut.androlib.res.decoder.ARSCDecoder.readConfig(ARSCDecoder.java:167)
    at brut.androlib.res.decoder.ARSCDecoder.readType(ARSCDecoder.java:133)
    at brut.androlib.res.decoder.ARSCDecoder.readPackage(ARSCDecoder.java:108)
    at brut.androlib.res.decoder.ARSCDecoder.readTable(ARSCDecoder.java:81)
    at brut.androlib.res.decoder.ARSCDecoder.decode(ARSCDecoder.java:49)
    at brut.androlib.res.AndrolibResources.getResPackagesFromApk(AndrolibResources.java:540)
    at brut.androlib.res.AndrolibResources.loadMainPkg(AndrolibResources.java:76)
    at brut.androlib.res.AndrolibResources.getResTable(AndrolibResources.java:68)
    at brut.androlib.Androlib.getResTable(Androlib.java:51)
    at brut.androlib.ApkDecoder.getResTable(ApkDecoder.java:191)
    at brut.androlib.ApkDecoder.decode(ApkDecoder.java:116)
    at brut.apktool.Main.cmdDecode(Main.java:148)
    at brut.apktool.Main.main(Main.java:77)
