### PR TITLE
Merge JesusFreke/smali#20 into fork / Fix building (2.0) on Windows

### DIFF
--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/BuildAndDecodeTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/BuildAndDecodeTest.java
@@ -161,11 +161,9 @@ public class BuildAndDecodeTest {
 
 	@Test
 	public void qualifiersTest() throws BrutException {
-		if (!System.getProperty("os.name").toLowerCase().contains("windows")) {
-			compareValuesFiles("values-mcc004-mnc4-en-rUS-ldrtl-sw100dp-w200dp-h300dp"
-					 + "-xlarge-long-land-desk-night-xhdpi-finger-keyssoft-12key"
-					 + "-navhidden-dpad/strings.xml");
-		}
+		compareValuesFiles("values-mcc004-mnc4-en-rUS-ldrtl-sw100dp-w200dp-h300dp"
+				+ "-xlarge-long-land-desk-night-xhdpi-finger-keyssoft-12key"
+				+ "-navhidden-dpad/strings.xml");
 	}
 
     @Test


### PR DESCRIPTION
Merge JesusFreke/smali#20 into fork: Use System.lineSeparator() for cross-platform safe EOL handling in runTest(). The patch fixes failing build attempts (`org.jf.baksmali.AnalysisTest > DuplicateTest FAILED [junit.framework.ComparisonFailure at AnalysisTest.java:107]`) on Windows systems.
