### PR TITLE
Supports Chinese Named apk On the windows platform, for example 'apktool...

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/Androlib.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/Androlib.java
@@ -555,8 +555,7 @@ public class Androlib {
                 zip_properties.put("encoding", "UTF-8");
 
                 // create filesystem
-                Path path = Paths.get(outFile.getAbsolutePath());
-                URI apkFileSystem = new URI("jar", path.toUri().toString(), null);
+                URI apkFileSystem = new URI("jar", outFile.toURI().toString(), null);
 
                 // loop through files inside
                 for (Map.Entry<String,String> entry : files.entrySet()) {


### PR DESCRIPTION
Supports Chinese Named apk On the windows platform

for example : 
    apktool d -f 中文测试.apk
    apktool b 中文测试
