### PR TITLE
DirUtil: fixed exception when decompiling with -r and no res folder exists in the apk

### DIFF
--- a/brut.j.dir/src/main/java/brut/directory/DirUtil.java
+++ b/brut.j.dir/src/main/java/brut/directory/DirUtil.java
@@ -76,6 +76,9 @@ public class DirUtil {
                 OS.rmdir(new File(out, fileName));
                 in.getDir(fileName).copyToDir(new File(out, fileName));
             } else {
+                if (fileName.equals("res") && !in.containsFile(fileName)) {
+                    return;
+                }
                 File outFile = new File(out, fileName);
                 outFile.getParentFile().mkdirs();
                 BrutIO.copyAndClose(in.getFileInput(fileName),


### PR DESCRIPTION
When you try to decompile an apk with the parameter -r and the apk doesn't have a res folder (there are some like the GoogleOneTimeInitializer.apk on the HTC One M8) then the decompile crashes with an exception:
Exception in thread "main" brut.androlib.AndrolibException: brut.directory.DirectoryException: Error copying file: res
        at brut.androlib.Androlib.decodeResourcesRaw(Androlib.java:110)

This patch checks when the filename is res that it exists in the apk. I made only the check for the res as I think if other files are missing then there should be an exception.

The same applies also to the compile of the apk when working with -r and no res folder.
