### PR TITLE
Ampersand in "&lt;" gets replaced with "&amp;" in plural strings

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -60,6 +60,7 @@ v2.0.0 (TBA)
 -Fixed (issue #757) - Download gradle binaries over https
 -Fixed (issue #402) - Fix issues when running user has no access to $HOME.
 -Fixed (issue #761) - Added proper support for BCP47 localization tags
+-Fixed (issue #658) - Fixes Ampersand in "&lt;" gets replaced with "&amp;" in plural strings
 -Fixed issue with attempting to decode .spi files as 9 patches (Thanks Furniel)
 -Fixed issue with APKs with multiple dex files.
 -Fixed issue with using Apktool without smali/baksmali for ApktoolProperties (Thanks teprrr)

--- a/brut.apktool/apktool-lib/src/main/java/org/xmlpull/mxp1_serializer/MXSerializer.java
+++ b/brut.apktool/apktool-lib/src/main/java/org/xmlpull/mxp1_serializer/MXSerializer.java
@@ -1009,10 +1009,13 @@ public class MXSerializer implements XmlSerializer {
 				}
 			} else {
 				if (ch == '&') {
-					if (i > pos)
-						out.write(text.substring(pos, i));
-					out.write("&amp;");
-					pos = i + 1;
+                    if(!(i < text.length() - 3 && text.charAt(i+1) == 'l' 
+                            && text.charAt(i+2) == 't' && text.charAt(i+3) == ';')){
+                        if (i > pos)
+                            out.write(text.substring(pos, i));
+                        out.write("&amp;");
+                        pos = i + 1;
+                    }
 				} else if (ch == '<') {
 					if (i > pos)
 						out.write(text.substring(pos, i));

--- a/brut.apktool/apktool-lib/src/test/resources/brut/apktool/testapp/res/values-mcc001/plurals.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/brut/apktool/testapp/res/values-mcc001/plurals.xml
@@ -16,4 +16,7 @@
         <item quantity="other">foo %d</item>
         <item quantity="one">foo 1</item>
     </plurals>
+    <plurals name="issue658">
+        <item quantity="one">&lt;b>%d&lt;/b> guide123</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
Fixes issue 658.