### PR TITLE
[WIP] Fix com.htc.resources decode

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
@@ -248,6 +248,8 @@ public class ARSCDecoder {
     private ResConfigFlags readConfigFlags() throws IOException,
             AndrolibException {
         int size = mIn.readInt();
+        int read = 0;
+
         if (size < 28) {
             throw new AndrolibException("Config size < 28");
         }
@@ -283,6 +285,7 @@ public class ARSCDecoder {
             screenLayout = mIn.readByte();
             uiMode = mIn.readByte();
             smallestScreenWidthDp = mIn.readShort();
+            read = 32;
         }
 
         short screenWidthDp = 0;
@@ -290,6 +293,7 @@ public class ARSCDecoder {
         if (size >= 36) {
             screenWidthDp = mIn.readShort();
             screenHeightDp = mIn.readShort();
+            read = 36;
         }
 
         char[] localeScript = {'\00'};
@@ -297,6 +301,7 @@ public class ARSCDecoder {
         if (size >= 48) {
             localeScript = this.readScriptOrVariantChar(4).toCharArray();
             localeVariant = this.readScriptOrVariantChar(8).toCharArray();
+            read = 48;
         }
 
         int exceedingSize = size - KNOWN_CONFIG_BYTES;
@@ -314,6 +319,11 @@ public class ARSCDecoder {
                         KNOWN_CONFIG_BYTES, exceedingBI));
                 isInvalid = true;
             }
+        }
+
+        int remainingSize = size - read;
+        if (remainingSize > 0) {
+            mIn.skipBytes(remainingSize);
         }
 
         return new ResConfigFlags(mcc, mnc, language, country,


### PR DESCRIPTION
So for bug #644 we usually get

```
Exception in thread "main" brut.androlib.AndrolibException: Multiple resources: spec=0x020500c0 dimen/title_primary_xs, config=-hdpi 
at brut.androlib.res.data.ResConfig.addResource(ResConfig.java:63)
```

Basically apktool isn't handling some qualifiers correctly, thus duplicated resources.

So after my latest Lollipop changes. That error became this.

```
Exception in thread "main" brut.androlib.AndrolibException: Could not decode arsc file
	...
Caused by: java.io.IOException: Expected: 0x00000008, got: 0x00000000
```

Basically, `com.htc.resources` has a 40 byte header when Lollipop has `48` and kitkat has `36`. This apk as mentioned before has 4 unknown bytes packed into its header. Since copying and pasting this isn't working.

Here is a screenshot of `aapt d configurations com.htc.resources.apk`

![snip](https://cloud.githubusercontent.com/assets/611784/6769281/dbdec174-d062-11e4-9aff-2e0bf398af20.png)

So the changes so far (Work in Progress) here. Simply get the error back to the `multiple resources` one. Since we check out how many bytes we have read, if there are unread bytes we simply skip them. Now skipping them causing this error, so these 4 bytes play into the HTC qualifiers.

I should either investigate the `framework.jar` from a ROM of HTC that experiences this or enumerate all possibilities of those 4 bytes (`4 bytes`, `2 shorts`, `1 int`, `chars`, `etc`)
