### PR TITLE
Propagate the raw int values to callers

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResBoolValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResBoolValue.java
@@ -22,8 +22,8 @@ package brut.androlib.res.data.value;
 public class ResBoolValue extends ResScalarValue {
     private final boolean mValue;
 
-    public ResBoolValue(boolean value, String rawValue) {
-        super("bool", rawValue);
+    public ResBoolValue(boolean value, int rawIntValue, String rawValue) {
+        super("bool", rawIntValue, rawValue);
         this.mValue = value;
     }
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResFileValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResFileValue.java
@@ -21,10 +21,11 @@ import brut.androlib.AndrolibException;
 /**
  * @author Ryszard Wiśniewski <brut.alll@gmail.com>
  */
-public class ResFileValue extends ResValue {
+public class ResFileValue extends ResIntBasedValue {
     private final String mPath;
 
-    public ResFileValue(String path) {
+    public ResFileValue(String path, int rawIntValue) {
+        super(rawIntValue);
         this.mPath = path;
     }
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResIntBasedValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResIntBasedValue.java
@@ -17,22 +17,16 @@
 package brut.androlib.res.data.value;
 
 /**
- * @author Ryszard Wiśniewski <brut.alll@gmail.com>
+ * @author Matt Mastracci <matthew@mastracci.com>
  */
-public class ResFloatValue extends ResScalarValue {
-    private final float mValue;
+public class ResIntBasedValue extends ResValue {
+    private int mRawIntValue;
 
-    public ResFloatValue(float value, int rawIntValue, String rawValue) {
-        super("float", rawIntValue, rawValue);
-        this.mValue = value;
+    protected ResIntBasedValue(int rawIntValue) {
+        mRawIntValue = rawIntValue;
     }
 
-    public float getValue() {
-        return mValue;
-    }
-
-    @Override
-    protected String encodeAsResXml() {
-        return String.valueOf(mValue);
+    public int getRawIntValue() {
+        return mRawIntValue;
     }
 }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResIntValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResIntValue.java
@@ -32,7 +32,7 @@ public class ResIntValue extends ResScalarValue {
     }
 
     public ResIntValue(int value, String rawValue, String type) {
-        super(type, rawValue);
+        super(type, value, rawValue);
         this.mValue = value;
     }
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResScalarValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResScalarValue.java
@@ -27,12 +27,13 @@ import org.xmlpull.v1.XmlSerializer;
 /**
  * @author Ryszard Wiśniewski <brut.alll@gmail.com>
  */
-public abstract class ResScalarValue extends ResValue implements
+public abstract class ResScalarValue extends ResIntBasedValue implements
         ResXmlEncodable, ResValuesXmlSerializable {
     protected final String mType;
     protected final String mRawValue;
 
-    protected ResScalarValue(String type, String rawValue) {
+    protected ResScalarValue(String type, int rawIntValue, String rawValue) {
+        super(rawIntValue);
         mType = type;
         mRawValue = rawValue;
     }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResStringValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResStringValue.java
@@ -27,12 +27,12 @@ import org.xmlpull.v1.XmlSerializer;
  */
 public class ResStringValue extends ResScalarValue {
 
-    public ResStringValue(String value) {
-        this(value, "string");
+    public ResStringValue(String value, int rawValue) {
+        this(value, rawValue, "string");
     }
 
-    public ResStringValue(String value, String type) {
-        super(type, value);
+    public ResStringValue(String value, int rawValue, String type) {
+        super(type, rawValue, value);
     }
 
     @Override

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResValueFactory.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResValueFactory.java
@@ -41,15 +41,15 @@ public class ResValueFactory {
             case TypedValue.TYPE_ATTRIBUTE:
                 return newReference(value, rawValue, true);
             case TypedValue.TYPE_STRING:
-                return new ResStringValue(rawValue);
+                return new ResStringValue(rawValue, value);
             case TypedValue.TYPE_FLOAT:
-                return new ResFloatValue(Float.intBitsToFloat(value), rawValue);
+                return new ResFloatValue(Float.intBitsToFloat(value), value, rawValue);
             case TypedValue.TYPE_DIMENSION:
                 return new ResDimenValue(value, rawValue);
             case TypedValue.TYPE_FRACTION:
                 return new ResFractionValue(value, rawValue);
             case TypedValue.TYPE_INT_BOOLEAN:
-                return new ResBoolValue(value != 0, rawValue);
+                return new ResBoolValue(value != 0, value, rawValue);
             case TypedValue.TYPE_DYNAMIC_REFERENCE:
                 return newReference(value, rawValue);
         }
@@ -66,11 +66,11 @@ public class ResValueFactory {
         throw new AndrolibException("Invalid value type: " + type);
     }
 
-    public ResValue factory(String value) {
+    public ResIntBasedValue factory(String value, int rawValue) {
         if (value.startsWith("res/")) {
-            return new ResFileValue(value);
+            return new ResFileValue(value, rawValue);
         }
-        return new ResStringValue(value);
+        return new ResStringValue(value, rawValue);
     }
 
     public ResBagValue bagFactory(int parent,

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResFileDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResFileDecoder.java
@@ -101,7 +101,7 @@ public class ResFileDecoder {
             LOGGER.log(Level.SEVERE, String.format(
                     "Could not decode file, replacing by FALSE value: %s",
                     inFileName, outFileName), ex);
-            res.replace(new ResBoolValue(false, null));
+            res.replace(new ResBoolValue(false, 0, null));
         }
     }
 


### PR DESCRIPTION
This makes the raw int resource values available to callers for resource types that are based on the int value read from the resource file.

The raw int available here is the same int that you'll find on TypedValue.data.