### PR TITLE
Set the overwrite flag with true for the unknown multiple resources c…

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResResSpec.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResResSpec.java
@@ -104,7 +104,7 @@ public class ResResSpec {
     }
 
     public void addResource(ResResource res) throws AndrolibException {
-        addResource(res, false);
+        addResource(res, true);
     }
 
     public void addResource(ResResource res, boolean overwrite) throws AndrolibException {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResType.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResType.java
@@ -52,7 +52,7 @@ public class ResType {
     }
 
     public void addResource(ResResource res) throws AndrolibException {
-        addResource(res, false);
+        addResource(res, true);
     }
 
     public void removeResource(ResResource res) throws AndrolibException {


### PR DESCRIPTION
…onfig

Some android mobile phone manufacturers will modify the aapt tool, it will lead to decode unsuccessfully.
If the overwrite flag is true, the decoded files is not complete fully, but decode successfully.