### PR TITLE
Fixes issue #1122

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/Androlib.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/Androlib.java
@@ -171,9 +171,11 @@ public class Androlib {
                 if (isAPKFileNames(file) && !NO_COMPRESS_PATTERN.matcher(file).find()) {
                     if (unk.getCompressionLevel(file) == 0) {
                         ext = FilenameUtils.getExtension(file);
-
+                        if (ext.isEmpty()) {
+                            ext = file;
+                        }
                         if (! uncompressedExtensions.contains(ext)) {
-                            uncompressedExtensions.add(FilenameUtils.getExtension(file));
+                            uncompressedExtensions.add(ext);
                         }
                     }
                 }


### PR DESCRIPTION
If we have no file extension apktool.yml's doNotCompress record for this file will look like: ''. It will cause build error. So use file name for that files.