### PR TITLE
decoder: Extend "keep-broken-res" to also ignore duplicate resources

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
@@ -73,6 +73,8 @@ public class ApkDecoder {
     public void decode() throws AndrolibException, IOException, DirectoryException {
         File outDir = getOutDir();
 
+	AndrolibResources.sKeepBroken = mKeepBrokenResources;
+
         if (!mForceDelete && outDir.exists()) {
             throw new OutDirExistsException();
         }
@@ -239,7 +241,6 @@ public class ApkDecoder {
                 throw new AndrolibException(
                         "Apk doesn't contain either AndroidManifest.xml file or resources.arsc file");
             }
-            AndrolibResources.sKeepBroken = mKeepBrokenResources;
             mResTable = mAndrolib.getResTable(mApkFile, hasResources);
         }
         return mResTable;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
@@ -249,8 +249,18 @@ public class ARSCDecoder {
         }
         ResResource res = new ResResource(mType, spec, value);
 
-        mType.addResource(res);
-        spec.addResource(res);
+        try {
+	    mType.addResource(res);
+	    spec.addResource(res);
+	} catch (AndrolibException e) {
+	    if (mKeepBroken) {
+		mType.addResource(res, true);
+		spec.addResource(res, true);
+		System.err.println("ignoring exception: " + e);
+	    } else {
+		throw e;
+	    }
+	}
         mPkg.addResource(res);
     }
 


### PR DESCRIPTION
If I decode the framework-res.apk from the recent release of the Huawei Honor 5x I get this exception:
```
Exception in thread "main" brut.androlib.AndrolibException: Multiple resources: spec=0x01040384 string/lockscreen_carrier_default, config=[DEFAULT]
	at brut.androlib.res.data.ResConfig.addResource(ResConfig.java:63)
	at brut.androlib.res.data.ResConfig.addResource(ResConfig.java:56)
	at brut.androlib.res.decoder.ARSCDecoder.readEntry(ARSCDecoder.java:223)
	at brut.androlib.res.decoder.ARSCDecoder.readConfig(ARSCDecoder.java:191)
	at brut.androlib.res.decoder.ARSCDecoder.readType(ARSCDecoder.java:159)
	at brut.androlib.res.decoder.ARSCDecoder.readPackage(ARSCDecoder.java:116)
	at brut.androlib.res.decoder.ARSCDecoder.readTable(ARSCDecoder.java:78)
	at brut.androlib.res.decoder.ARSCDecoder.decode(ARSCDecoder.java:47)
	at brut.androlib.res.AndrolibResources.getResPackagesFromApk(AndrolibResources.java:544)
	at brut.androlib.res.AndrolibResources.loadMainPkg(AndrolibResources.java:63)
	at brut.androlib.res.AndrolibResources.getResTable(AndrolibResources.java:55)
	at brut.androlib.Androlib.getResTable(Androlib.java:65)
	at brut.androlib.ApkDecoder.setTargetSdkVersion(ApkDecoder.java:197)
	at brut.androlib.ApkDecoder.decode(ApkDecoder.java:96)
	at brut.apktool.Main.cmdDecode(Main.java:165)
	at brut.apktool.Main.main(Main.java:81)
```
It seems to me like `--keep-broken-res` should also continue processing after this error.  This pull request changes the code to do so.
