### PR TITLE
#1186 Performance: usage of String.format in ARSCDecoder.addMissingResSpecs

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
@@ -435,7 +435,7 @@ public class ARSCDecoder {
                 continue;
             }
 
-            ResResSpec spec = new ResResSpec(new ResID(resId | i), String.format("APKTOOL_DUMMY_%04x", i), mPkg, mTypeSpec);
+            ResResSpec spec = new ResResSpec(new ResID(resId | i), "APKTOOL_DUMMY_" + Integer.toHexString(i), mPkg, mTypeSpec);
 
             // If we already have this resID dont add it again.
             if (! mPkg.hasResSpec(new ResID(resId | i))) {


### PR DESCRIPTION
Addresses issue #1186

Reduces the time it takes to parse the Android framework by ~50%.

The synthesized name now has no leading zeroes, but this doesn't appear to matter since the numeric part of the name isn't used anywhere.