### PR TITLE
Reinstate minimalistic debug option to inject android:debuggable with aapt

### DIFF
--- a/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
+++ b/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
@@ -199,8 +199,8 @@ public class Main {
             apkOptions.forceBuildAll = true;
         }
         if (cli.hasOption("d") || cli.hasOption("debug")) {
-            System.err.println("SmaliDebugging has been removed in 2.1.0 onward. Please see: https://github.com/iBotPeaches/Apktool/issues/1061");
-            System.exit(1);
+            System.out.println("SmaliDebugging has been removed in 2.1.0 onward. Please see: https://github.com/iBotPeaches/Apktool/issues/1061");
+            apkOptions.debugMode = true;
         }
         if (cli.hasOption("v") || cli.hasOption("verbose")) {
             apkOptions.verbose = true;
@@ -286,7 +286,7 @@ public class Main {
                 .create();
 
         Option debugBuiOption = OptionBuilder.withLongOpt("debug")
-                .withDescription("Builds in debug mode. Check project page for more info.")
+                .withDescription("Sets android:debuggable to \"true\" in the APK's compiled manifest")
                 .create("d");
 
         Option noDbgOption = OptionBuilder.withLongOpt("no-debug-info")

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkOptions.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkOptions.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 
 public class ApkOptions {
     public boolean forceBuildAll = false;
+    public boolean debugMode = false;
     public boolean verbose = false;
     public boolean copyOriginalFiles = false;
     public boolean updateFiles = false;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
@@ -346,6 +346,9 @@ final public class AndrolibResources {
         if (apkOptions.updateFiles) {
             cmd.add("-u");
         }
+        if (apkOptions.debugMode) { // inject debuggable="true" into manifest
+            cmd.add("--debug-mode");
+        }
         // force package id so that some frameworks build with correct id
         // disable if user adds own aapt (can't know if they have this feature)
         if (mPackageId != null && ! customAapt && ! mSharedLibrary) {


### PR DESCRIPTION
Even when using smalidea (the recommended solution) the APK you're debugging must still be debuggable. As such, this is important functionality to retain.

fixes #1235 