### PR TITLE
Adding new option. Keep META-INF directory

### DIFF
--- a/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
+++ b/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
@@ -211,6 +211,9 @@ public class Main {
         if (cli.hasOption("c") || cli.hasOption("copy-original")) {
             apkOptions.copyOriginalFiles = true;
         }
+        if (cli.hasOption("k") || cli.hasOption("keep-meta")) {
+            apkOptions.keepMetaInf = true;
+        }
         if (cli.hasOption("p") || cli.hasOption("frame-path")) {
             apkOptions.frameworkFolderLocation = cli.getOptionValue("p");
         }
@@ -336,6 +339,10 @@ public class Main {
                 .withDescription("Copies original AndroidManifest.xml and META-INF. See project page for more info.")
                 .create("c");
 
+        Option keepMetaInfOption = OptionBuilder.withLongOpt("keep-meta")
+                .withDescription("Copies original META-INF. See project page for more info.")
+                .create("k");
+
         Option tagOption = OptionBuilder.withLongOpt("tag")
                 .withDescription("Tag frameworks using <tag>.")
                 .hasArg(true)
@@ -371,6 +378,7 @@ public class Main {
             BuildOptions.addOption(debugBuiOption);
             BuildOptions.addOption(aaptOption);
             BuildOptions.addOption(originalOption);
+            BuildOptions.addOption(keepMetaInfOption);
         }
 
         // add global options
@@ -414,6 +422,7 @@ public class Main {
         allOptions.addOption(debugBuiOption);
         allOptions.addOption(aaptOption);
         allOptions.addOption(originalOption);
+        allOptions.addOption(keepMetaInfOption);
         allOptions.addOption(verboseOption);
         allOptions.addOption(quietOption);
     }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/Androlib.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/Androlib.java
@@ -283,6 +283,7 @@ public class Androlib {
         buildLib(appDir);
         buildLibs(appDir);
         buildCopyOriginalFiles(appDir);
+        buildCopyMetaInfFiles(appDir);
         buildApk(appDir, outFile);
 
         // we must go after the Apk is built, and copy the files in via Zip
@@ -528,6 +529,24 @@ public class Androlib {
                     }
                     if (in.containsDir("META-INF")) {
                         LOGGER.info("Copy META-INF...");
+                        in.copyToDir(new File(appDir, APK_DIRNAME), "META-INF");
+                    }
+                } catch (DirectoryException ex) {
+                    throw new AndrolibException(ex);
+                }
+            }
+        }
+    }
+
+    public void buildCopyMetaInfFiles(File appDir)
+            throws AndrolibException {
+        if (apkOptions.keepMetaInf) {
+            File originalDir = new File(appDir, "original");
+            if(originalDir.exists()) {
+                try {
+                    LOGGER.info("Copy META-INF files...");
+                    Directory in = (new ExtFile(originalDir)).getDirectory();
+                    if (in.containsDir("META-INF")) {
                         in.copyToDir(new File(appDir, APK_DIRNAME), "META-INF");
                     }
                 } catch (DirectoryException ex) {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkOptions.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkOptions.java
@@ -21,6 +21,7 @@ public class ApkOptions {
     public boolean forceBuildAll = false;
     public boolean verbose = false;
     public boolean copyOriginalFiles = false;
+    public boolean keepMetaInf = false;
     public boolean updateFiles = false;
     public boolean isFramework = false;
     public boolean resourcesAreCompressed = false;


### PR DESCRIPTION
A very similar method to "copy-original".
Just copies the META-INF directory. I found an application which used this directory during application runtime. Next to standard results from jarsigner they are storing other kind of signatures.

I've named params "--keep-meta" and "-k" but it up to you @iBotPeaches to choose :)
