### PR TITLE
fix ZipException for missing compressed size

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
@@ -633,10 +633,15 @@ final public class AndrolibResources {
                 byte[] manifest = IOUtils.toByteArray(in);
                 CRC32 manifestCrc = new CRC32();
                 manifestCrc.update(manifest);
-                entry.setSize(manifest.length);
-                entry.setCompressedSize(manifest.length);
-                entry.setCrc(manifestCrc.getValue());
-                out.putNextEntry(entry);
+                ZipEntry wEntry = new ZipEntry(entry.getName());
+                wEntry.setSize(manifest.length);
+                if (wEntry.getMethod() == ZipEntry.STORED) {
+                    wEntry.setCompressedSize(manifest.length);
+                } else  {
+                    wEntry.setCompressedSize(-1);
+                }
+                wEntry.setCrc(manifestCrc.getValue());
+                out.putNextEntry(wEntry);
                 out.write(manifest);
                 out.closeEntry();
             }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
@@ -634,7 +634,7 @@ final public class AndrolibResources {
                 CRC32 manifestCrc = new CRC32();
                 manifestCrc.update(manifest);
                 entry.setSize(manifest.length);
-                entry.setCompressedSize(-1);
+                entry.setCompressedSize(manifest.length);
                 entry.setCrc(manifestCrc.getValue());
                 out.putNextEntry(entry);
                 out.write(manifest);


### PR DESCRIPTION
```
apktool if -p . framework-res.apk                                                                                                                                                  11:58:33
Exception in thread "main" brut.androlib.AndrolibException: java.util.zip.ZipException: STORED entry missing size, compressed size, or crc-32
	at brut.androlib.res.AndrolibResources.installFramework(AndrolibResources.java:647)
	at brut.androlib.res.AndrolibResources.installFramework(AndrolibResources.java:592)
	at brut.androlib.Androlib.installFramework(Androlib.java:643)
	at brut.apktool.Main.cmdInstallFramework(Main.java:239)
	at brut.apktool.Main.main(Main.java:87)
	at com.rover12421.shaka.cli.Main.main(Main.java:95)
Caused by: java.util.zip.ZipException: STORED entry missing size, compressed size, or crc-32
	at java.util.zip.ZipOutputStream.putNextEntry(ZipOutputStream.java:224)
	at brut.androlib.res.AndrolibResources.installFramework(AndrolibResources.java:639)
	... 5 more
```

```
 java -version                                                                                                                                                                      13:18:42
java version "1.8.0_77"
Java(TM) SE Runtime Environment (build 1.8.0_77-b03)
Java HotSpot(TM) 64-Bit Server VM (build 25.77-b03, mixed mode)
```

simple APK : http://pan.baidu.com/s/1slkVmDv
