### PR TITLE
Skip additional payload data of TYPE chunk

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
@@ -154,6 +154,12 @@ public class ARSCDecoder {
 
         while (type == Header.TYPE_TYPE) {
             readTableType();
+            
+            // skip "TYPE 8 chunks" and/or padding data at the end of this chunk
+            if(mCountIn.getCount() < mHeader.endPosition) {
+                mCountIn.skip(mHeader.endPosition - mCountIn.getCount());
+            }
+            
             type = nextChunk().type;
 
             addMissingResSpecs();


### PR DESCRIPTION
Some APKs' arsc has additional payload data (like TYPE 8 chunks and/or padding) in the TYPE chunk. After the ARSCDecoder read such kind of chunk, it acts erratically. Most of the time, it just stops parsing the ARSC, therefore, some resources are not decoded because they are not in the apktool's resources' spec table.

The example APKs, attached below, is from Huawei P9 Plus ROM (VIEL29C636B170). Both APK's resource are successfully decoded by aapt included in build tools v24.

[Gallery2.apk.zip](https://github.com/iBotPeaches/Apktool/files/478287/Gallery2.apk.zip)
[HwCamera2.apk.zip](https://github.com/iBotPeaches/Apktool/files/478286/HwCamera2.apk.zip)
