### PR TITLE
Prevents double escaping of special chars in plurals items

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResPluralsValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResPluralsValue.java
@@ -54,7 +54,7 @@ public class ResPluralsValue extends ResBagValue implements
 
             serializer.startTag(null, "item");
             serializer.attribute(null, "quantity", QUANTITY_MAP[i]);
-            serializer.text(ResXmlEncoders.enumerateNonPositionalSubstitutionsIfRequired(item.encodeAsResXmlValue()));
+            serializer.text(ResXmlEncoders.enumerateNonPositionalSubstitutionsIfRequired(item.encodeAsResXmlNonEscapedItemValue()));
             serializer.endTag(null, "item");
         }
         serializer.endTag(null, "plurals");


### PR DESCRIPTION
Sme problem than https://github.com/iBotPeaches/Apktool/commit/f93a3123080ef9bacdb1e56bc1fa0a6169b4285d but for plurals items)