### PR TITLE
Fix dead links

### DIFF
--- a/install/index.md
+++ b/install/index.md
@@ -14,7 +14,7 @@ title: Apktool - How to Install
 ## Installation for Apktool
   * **Windows**:
     1. Download Windows [wrapper script](https://raw.githubusercontent.com/iBotPeaches/Apktool/master/scripts/windows/apktool.bat) (Right click, Save Link As `apktool.bat`)
-    1. Download apktool-2 ([find newest here](https://bitbucket.org/iBotPeaches/apktool/downloads))
+    1. Download apktool-2 ([find newest here](https://bitbucket.org/iBotPeaches/apktool/downloads/))
     1. Rename downloaded jar to `apktool.jar`
     1. Move both files (`apktool.jar` & `apktool.bat`) to your Windows directory (Usually `C://Windows`)
     1. If you do not have access to `C://Windows`, you may place the two files anywhere then add that directory to your Environment Variables System PATH variable.
@@ -22,7 +22,7 @@ title: Apktool - How to Install
 
   * **Linux**:
     1. Download Linux [wrapper script](https://raw.githubusercontent.com/iBotPeaches/Apktool/master/scripts/linux/apktool) (Right click, Save Link As `apktool`)
-    1. Download apktool-2 ([find newest here](https://bitbucket.org/iBotPeaches/apktool/downloads))
+    1. Download apktool-2 ([find newest here](https://bitbucket.org/iBotPeaches/apktool/downloads/))
     1. Make sure you have the 32bit libraries (`ia32-libs`) downloaded and installed by your linux package manager, if you are on a 64bit unix system.
     1. (This helps provide support for the 32bit native binary aapt, which is required by apktool)
     1. Rename downloaded jar to `apktool.jar`
@@ -32,7 +32,7 @@ title: Apktool - How to Install
 
   * **Mac OS X**:
     1. Download Mac [wrapper script](https://raw.githubusercontent.com/iBotPeaches/Apktool/master/scripts/osx/apktool) (Right click, Save Link As `apktool`)
-    1. Download apktool-2 ([find newest here](https://bitbucket.org/iBotPeaches/apktool/downloads))
+    1. Download apktool-2 ([find newest here](https://bitbucket.org/iBotPeaches/apktool/downloads/))
     1. Rename downloaded jar to `apktool.jar`
     1. Move both files (`apktool.jar` & `apktool`) to `/usr/local/bin` (root needed)
     1. Make sure both files are executable (`chmod +x`)


### PR DESCRIPTION
I don't know why bitbucket download link need a forward slash at the end, anyway I fix it.