### PR TITLE
In case of a grayscale + alpha 9patch, work-around JDK.

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/Res9patchStreamDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/Res9patchStreamDecoder.java
@@ -20,6 +20,8 @@ import brut.androlib.AndrolibException;
 import brut.androlib.err.CantFind9PatchChunk;
 import brut.util.ExtDataInput;
 import java.awt.image.BufferedImage;
+import java.awt.image.Raster;
+import java.awt.image.WritableRaster;
 import java.io.*;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageTypeSpecifier;
@@ -40,7 +42,23 @@ public class Res9patchStreamDecoder implements ResStreamDecoder {
             int w = im.getWidth(), h = im.getHeight();
 
             BufferedImage im2 = new BufferedImage(w+2, h+2, BufferedImage.TYPE_INT_ARGB);
-            im2.createGraphics().drawImage(im, 1, 1, w, h, null);
+            if(im.getType() == BufferedImage.TYPE_CUSTOM) {
+                //TODO: Ensure this is gray + alpha case?
+                Raster srcRaster = im.getRaster();
+                WritableRaster dstRaster = im2.getRaster();
+                int[] gray = null, alpha = null;
+                for (int y = 0; y < im.getHeight(); y++) {
+                    gray = srcRaster.getSamples(0, y, w, 1, 0, gray);
+                    alpha = srcRaster.getSamples(0, y, w, 1, 1, alpha);
+
+                    dstRaster.setSamples(1, y+1, w, 1, 0, gray);
+                    dstRaster.setSamples(1, y+1, w, 1, 1, gray);
+                    dstRaster.setSamples(1, y+1, w, 1, 2, gray);
+                    dstRaster.setSamples(1, y+1, w, 1, 3, alpha);
+                }
+            } else {
+                im2.createGraphics().drawImage(im, 1, 1, w, h, null);
+            }
 
             NinePatch np = getNinePatch(data);
             drawHLine(im2, h + 1, np.padLeft + 1, w - np.padRight);


### PR DESCRIPTION
Original code:
https://worldwind31.arc.nasa.gov/svn/trunk/WorldWind/src/gov/nasa/worldwind/util/gdal/GDALUtils.java
/JDK-5051418
Fixes #1508