### PR TITLE
Making framework read in much faster

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResResSpec.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResResSpec.java
@@ -35,12 +35,12 @@ public class ResResSpec {
         this.mId = id;
         String cleanName;
 
-        try {
-            ResResSpec resResSpec = type.getResSpec(name);
+        ResResSpec resResSpec = type.getResSpecUnsafe(name);
+        if (resResSpec != null)
             cleanName = name + "_APKTOOL_DUPLICATENAME_" + id.toString();
-        } catch (AndrolibException ex) {
+        else
             cleanName = (name.isEmpty() ? ("APKTOOL_DUMMYVAL_" + id.toString()) : name);
-        }
+        
         this.mName = cleanName;
         this.mPackage = pkg;
         this.mType = type;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResTypeSpec.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResTypeSpec.java
@@ -62,11 +62,15 @@ public final class ResTypeSpec {
     }
 
     public ResResSpec getResSpec(String name) throws AndrolibException {
-        ResResSpec spec = mResSpecs.get(name);
+        ResResSpec spec = getResSpecUnsafe(name);
         if (spec == null) {
             throw new UndefinedResObject(String.format("resource spec: %s/%s", getName(), name));
         }
         return spec;
+    }
+
+    public ResResSpec getResSpecUnsafe(String name) {
+        return mResSpecs.get(name);
     }
 
     public void removeResSpec(ResResSpec spec) throws AndrolibException {


### PR DESCRIPTION
Basically, on import getResSpec is called multiple times and very often throws an exception. Returning null is much faster and therefore in cases where the caller does not rely on a thrown exception, it may use the new getResSpecUnsafe method.