### PR TITLE
getResourceAsStream relative based on calling class.

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
@@ -783,18 +783,18 @@ final public class AndrolibResources {
         try {
             if (OSDetection.isMacOSX()) {
                 if (OSDetection.is64Bit()) {
-                    aaptBinary = Jar.getResourceAsFile("/prebuilt/aapt/macosx/64/aapt");
+                    aaptBinary = Jar.getResourceAsFile("/prebuilt/aapt/macosx/64/aapt", AndrolibResources.class);
                 } else {
-                    aaptBinary = Jar.getResourceAsFile("/prebuilt/aapt/macosx/32/aapt");
+                    aaptBinary = Jar.getResourceAsFile("/prebuilt/aapt/macosx/32/aapt", AndrolibResources.class);
                 }
             } else if (OSDetection.isUnix()) {
                 if (OSDetection.is64Bit()) {
-                    aaptBinary = Jar.getResourceAsFile("/prebuilt/aapt/linux/64/aapt");
+                    aaptBinary = Jar.getResourceAsFile("/prebuilt/aapt/linux/64/aapt", AndrolibResources.class);
                 } else {
-                    aaptBinary = Jar.getResourceAsFile("/prebuilt/aapt/linux/32/aapt");
+                    aaptBinary = Jar.getResourceAsFile("/prebuilt/aapt/linux/32/aapt", AndrolibResources.class);
                 }
             } else if (OSDetection.isWindows()) {
-                aaptBinary = Jar.getResourceAsFile("/prebuilt/aapt/windows/aapt.exe");
+                aaptBinary = Jar.getResourceAsFile("/prebuilt/aapt/windows/aapt.exe", AndrolibResources.class);
             } else {
                 LOGGER.warning("Unknown Operating System: " + OSDetection.returnOS());
                 return null;

--- a/brut.j.util/src/main/java/brut/util/Jar.java
+++ b/brut.j.util/src/main/java/brut/util/Jar.java
@@ -31,14 +31,18 @@ abstract public class Jar {
     private final static Set<String> mLoaded = new HashSet<String>();
     private final static Map<String, File> mExtracted =
         new HashMap<String, File>();
-
-    public static File getResourceAsFile(String name) throws BrutException {
+		
+	public static File getResourceAsFile(String name, Class clazz) throws BrutException {
         File file = mExtracted.get(name);
         if (file == null) {
-            file = extractToTmp(name);
+            file = extractToTmp(name, clazz);
             mExtracted.put(name, file);
         }
         return file;
+    }
+
+    public static File getResourceAsFile(String name) throws BrutException {
+        return getResourceAsFile(name, Class.class);
     }
 
     public static void load(String libPath) {
@@ -56,14 +60,18 @@ abstract public class Jar {
         System.load(libFile.getAbsolutePath());
     }
 
-    public static File extractToTmp(String resourcePath) throws BrutException {
-        return extractToTmp(resourcePath, "brut_util_Jar_");
+    public static File extractToTmp(String resourcePath, Class clazz) throws BrutException {
+        return extractToTmp(resourcePath, "brut_util_Jar_", clazz);
+    }
+	
+	public static File extractToTmp(String resourcePath) throws BrutException {
+        return extractToTmp(resourcePath, Class.class);
     }
 
-    public static File extractToTmp(String resourcePath, String tmpPrefix)
+    public static File extractToTmp(String resourcePath, String tmpPrefix, Class clazz)
             throws BrutException {
         try {
-            InputStream in = Class.class.getResourceAsStream(resourcePath);
+            InputStream in = clazz.getResourceAsStream(resourcePath);
             if (in == null) {
                 throw new FileNotFoundException(resourcePath);
             }
@@ -79,4 +87,8 @@ abstract public class Jar {
                 "Could not extract resource: " + resourcePath, ex);
         }
     }
+	
+	public static File extractToTmp(String resourcePath, String tmpPrefix) throws BrutException {
+		return extractToTmp(resourcePath, tmpPrefix, Class.class);
+	}
 }


### PR DESCRIPTION
Class.class.getResourceAsStream tries to load resource from root directory. This fails when apktool is built into a fat jar like Spring boot executable so that the classloader tries to load the resource from the root directory of the Spring boot jar instead of that of the bundled appktool jar.

fixes #1543 