### PR TITLE
Support bounding targetSdkVersion between minSdkVersion and maxSdkVer…

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
@@ -307,6 +307,22 @@ final public class AndrolibResources {
         mSharedLibrary = flag;
     }
 
+    // Ensure that targetSdkVersion is between minSdkVersion/maxSdkVersion if
+    // they are specified.
+    private String checkTargetSdkVersionBounds()
+    {
+        int target = Integer.parseInt(mTargetSdkVersion);
+        int min = (mMinSdkVersion != null) ? Integer.parseInt(mMinSdkVersion) : 0;
+        int max = (mMaxSdkVersion != null) ? Integer.parseInt(mMaxSdkVersion) : target;
+
+        // Your APK seems broken otherwise.
+        assert (min <= max);
+
+        target = Math.min(max, target);
+        target = Math.max(min, target);
+        return Integer.toString(target);
+    }
+
     public void aaptPackage(File apkFile, File manifest, File resDir, File rawDir, File assetDir, File[] include)
             throws AndrolibException {
 
@@ -368,7 +384,7 @@ final public class AndrolibResources {
         }
         if (mTargetSdkVersion != null) {
             cmd.add("--target-sdk-version");
-            cmd.add(mTargetSdkVersion);
+            cmd.add(checkTargetSdkVersionBounds());
         }
         if (mMaxSdkVersion != null) {
             cmd.add("--max-sdk-version");


### PR DESCRIPTION
…sion

It is possible to create a an AndroidStudio project that uses the following
nonsense settings:

    defaultConfig {
        minSdkVersion 15
        maxSdkVersion 19
        targetSdkVersion 25
    }

The application is successfully built by Android Studio, and the APK
works when installed on the relevant devices, however the app cannot
be re-built with Apktool afterwards.

This patch works around the problem by explicitly setting the
targetSdkVersion to the max of the maxSdkVersion and min of the minSdkVersion
only if these are specified.