### PR TITLE
Remove .exit() falls from library code

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
@@ -791,13 +791,11 @@ final public class AndrolibResources {
         File dir = new File(path);
 
         if (!dir.isDirectory()) {
-            LOGGER.severe("--frame-path is set to a file, not a directory.");
-            System.exit(1);
+            throw new AndrolibException("--frame-path is set to a file, not a directory.");
         }
 
         if (dir.getParentFile() != null && dir.getParentFile().isFile()) {
-            LOGGER.severe("Please remove file at " + dir.getParentFile());
-            System.exit(1);
+            throw new AndrolibException("Please remove file at " + dir.getParentFile());
         }
 
         if (! dir.exists()) {


### PR DESCRIPTION
 - fixes #1640