### PR TITLE
Treat fonts as raw data, fixes #1662

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResFileDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResFileDecoder.java
@@ -62,6 +62,10 @@ public class ResFileDecoder {
                 decode(inDir, inFileName, outDir, outFileName, "raw");
                 return;
             }
+            if (typeName.equals("font") && !".xml".equals(ext)) {
+                decode(inDir, inFileName, outDir, outFileName, "raw");
+                return;
+            }
             if (typeName.equals("drawable") || typeName.equals("mipmap")) {
                 if (inFileName.toLowerCase().endsWith(".9" + ext)) {
                     outFileName = outResName + ".9" + ext;


### PR DESCRIPTION
The font files in the `font` folder are not encoded.  Treating them as `raw` on `decode` allows them to be properly dealt with during `build`.

Fixes #1662 