### PR TITLE
Add option to force decoding of AndroidManifest.xml

### DIFF
--- a/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
+++ b/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
@@ -124,6 +124,9 @@ public class Main {
         if (cli.hasOption("r") || cli.hasOption("no-res")) {
             decoder.setDecodeResources(ApkDecoder.DECODE_RESOURCES_NONE);
         }
+        if (cli.hasOption("force-manifest")) {
+            decoder.setForceDecodeManifest(ApkDecoder.FORCE_DECODE_MANIFEST_FULL);
+        }
         if (cli.hasOption("no-assets")) {
             decoder.setDecodeAssets(ApkDecoder.DECODE_ASSETS_NONE);
         }
@@ -286,6 +289,11 @@ public class Main {
                 .desc("Do not decode resources.")
                 .build();
 
+        Option forceManOption = Option.builder()
+                .longOpt("force-manifest")
+                .desc("Decode the APK's compiled manifest, even if decoding of resources is set to \"false\".")
+                .build();
+
         Option noAssetOption = Option.builder()
                 .longOpt("no-assets")
                 .desc("Do not decode assets.")
@@ -405,6 +413,7 @@ public class Main {
             DecodeOptions.addOption(analysisOption);
             DecodeOptions.addOption(apiLevelOption);
             DecodeOptions.addOption(noAssetOption);
+            DecodeOptions.addOption(forceManOption);
 
             BuildOptions.addOption(debugBuiOption);
             BuildOptions.addOption(aaptOption);
@@ -453,6 +462,7 @@ public class Main {
         allOptions.addOption(analysisOption);
         allOptions.addOption(debugDecOption);
         allOptions.addOption(noDbgOption);
+        allOptions.addOption(forceManOption);
         allOptions.addOption(noAssetOption);
         allOptions.addOption(keepResOption);
         allOptions.addOption(debugBuiOption);

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
@@ -104,6 +104,15 @@ public class ApkDecoder {
                 switch (mDecodeResources) {
                     case DECODE_RESOURCES_NONE:
                         mAndrolib.decodeResourcesRaw(mApkFile, outDir);
+                        if (mForceDecodeManifest == FORCE_DECODE_MANIFEST_FULL) {
+                            setTargetSdkVersion();
+                            setAnalysisMode(mAnalysisMode, true);
+
+                            // done after raw decoding of resources because copyToDir overwrites dest files
+                            if (hasManifest()) {
+                                mAndrolib.decodeManifestWithResources(mApkFile, outDir, getResTable());
+                            }
+                        }
                         break;
                     case DECODE_RESOURCES_FULL:
                         setTargetSdkVersion();
@@ -119,14 +128,12 @@ public class ApkDecoder {
                 // if there's no resources.asrc, decode the manifest without looking
                 // up attribute references
                 if (hasManifest()) {
-                    switch (mDecodeResources) {
-                        case DECODE_RESOURCES_NONE:
-                            mAndrolib.decodeManifestRaw(mApkFile, outDir);
-                            break;
-                        case DECODE_RESOURCES_FULL:
-                            mAndrolib.decodeManifestFull(mApkFile, outDir,
-                                    getResTable());
-                            break;
+                    if (mDecodeResources == DECODE_RESOURCES_FULL
+                            || mForceDecodeManifest == FORCE_DECODE_MANIFEST_FULL) {
+                        mAndrolib.decodeManifestFull(mApkFile, outDir, getResTable());
+                    }
+                    else {
+                        mAndrolib.decodeManifestRaw(mApkFile, outDir);
                     }
                 }
             }
@@ -188,6 +195,13 @@ public class ApkDecoder {
             throw new AndrolibException("Invalid decode resources mode");
         }
         mDecodeResources = mode;
+    }
+
+    public void setForceDecodeManifest(short mode) throws AndrolibException {
+        if (mode != FORCE_DECODE_MANIFEST_NONE && mode != FORCE_DECODE_MANIFEST_FULL) {
+            throw new AndrolibException("Invalid force decode manifest mode");
+        }
+        mForceDecodeManifest = mode;
     }
 
     public void setDecodeAssets(short mode) throws AndrolibException {
@@ -306,6 +320,9 @@ public class ApkDecoder {
     public final static short DECODE_RESOURCES_NONE = 0x0100;
     public final static short DECODE_RESOURCES_FULL = 0x0101;
 
+    public final static short FORCE_DECODE_MANIFEST_NONE = 0x0000;
+    public final static short FORCE_DECODE_MANIFEST_FULL = 0x0001;
+
     public final static short DECODE_ASSETS_NONE = 0x0000;
     public final static short DECODE_ASSETS_FULL = 0x0001;
 
@@ -417,6 +434,7 @@ public class ApkDecoder {
     private ResTable mResTable;
     private short mDecodeSources = DECODE_SOURCES_SMALI;
     private short mDecodeResources = DECODE_RESOURCES_FULL;
+    private short mForceDecodeManifest = FORCE_DECODE_MANIFEST_NONE;
     private short mDecodeAssets = DECODE_ASSETS_FULL;
     private boolean mForceDelete = false;
     private boolean mKeepBrokenResources = false;


### PR DESCRIPTION
Forces decoding of AndroidManifest.xml, even if `--no-res` is set. This is useful for analysis of the manifest if resources aren't relevant, saving the step of decoding other resources, which account for a significant amount of time.

I have set it to be an advanced option, named `--force-manifest` (feel free to change this). As such:
- Setting `--force-manifest` and not setting `--no-res` does not change the previous behavior of Apktool;
- Setting `--force-manifest` and `--no-res` decodes AndroidManifest.xml, but not other resources.

If accepted, I can submit another pull request regarding `gh-pages` with documentation for this option.