### PR TITLE
Patch APKTool to allow repeated entry offsets to appear

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ bin/
 # Tmp Files
 *.kate-swp
 *~
+*.DS_Store
 
 # IntelliJ
 *.iml
@@ -23,3 +24,6 @@ bin/
 
 # gradle/smali-patches patch smali/ into brut.apktool.smali/
 brut.apktool.smali/
+
+# Patches
+*.patch

--- a/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
+++ b/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
@@ -127,6 +127,9 @@ public class Main {
         if (cli.hasOption("force-manifest")) {
             decoder.setForceDecodeManifest(ApkDecoder.FORCE_DECODE_MANIFEST_FULL);
         }
+        if (cli.hasOption("manifest-only")) {
+            decoder.setManifestOnly(true);
+        }
         if (cli.hasOption("no-assets")) {
             decoder.setDecodeAssets(ApkDecoder.DECODE_ASSETS_NONE);
         }
@@ -294,6 +297,11 @@ public class Main {
                 .desc("Decode the APK's compiled manifest, even if decoding of resources is set to \"false\".")
                 .build();
 
+        Option manifestOnlyOption = Option.builder("mo")
+                .longOpt("manifest-only")
+                .desc("Only decode manifest.")
+                .build();
+
         Option noAssetOption = Option.builder()
                 .longOpt("no-assets")
                 .desc("Do not decode assets.")
@@ -431,6 +439,7 @@ public class Main {
         DecodeOptions.addOption(forceDecOption);
         DecodeOptions.addOption(noSrcOption);
         DecodeOptions.addOption(noResOption);
+        DecodeOptions.addOption(manifestOnlyOption);
 
         // add basic build options
         BuildOptions.addOption(outputBuiOption);

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
@@ -100,6 +100,13 @@ public class ApkDecoder {
 
             LOGGER.info("Using Apktool " + Androlib.getVersion() + " on " + mApkFile.getName());
 
+            if (mManifestOnly) {
+               setAnalysisMode(mAnalysisMode, true);
+               mAndrolib.decodeManifestWithResources(mApkFile, outDir, getResTable());
+               writeMetaFile();
+               return;
+            }
+
             if (hasResources()) {
                 switch (mDecodeResources) {
                     case DECODE_RESOURCES_NONE:
@@ -125,7 +132,7 @@ public class ApkDecoder {
                         break;
                 }
             } else {
-                // if there's no resources.asrc, decode the manifest without looking
+                // if there's no resources.arsc, decode the manifest without looking
                 // up attribute references
                 if (hasManifest()) {
                     if (mDecodeResources == DECODE_RESOURCES_FULL
@@ -240,6 +247,10 @@ public class ApkDecoder {
 
     public void setForceDelete(boolean forceDelete) {
         mForceDelete = forceDelete;
+    }
+
+    public void setManifestOnly(boolean manifestOnly) {
+        mManifestOnly = manifestOnly;
     }
 
     public void setFrameworkTag(String tag) throws AndrolibException {
@@ -416,7 +427,7 @@ public class ApkDecoder {
     }
 
     private void putFileCompressionInfo(MetaInfo meta) throws AndrolibException {
-        if (!mUncompressedFiles.isEmpty()) {
+        if (mUncompressedFiles != null && !mUncompressedFiles.isEmpty()) {
             meta.doNotCompress = mUncompressedFiles;
         }
     }
@@ -437,6 +448,7 @@ public class ApkDecoder {
     private short mForceDecodeManifest = FORCE_DECODE_MANIFEST_NONE;
     private short mDecodeAssets = DECODE_ASSETS_FULL;
     private boolean mForceDelete = false;
+    private boolean mManifestOnly = false;
     private boolean mKeepBrokenResources = false;
     private boolean mBakDeb = true;
     private Collection<String> mUncompressedFiles;


### PR DESCRIPTION
Hello! I'm sending this pull request on behalf of Facebook. We've been using a slightly modified APKTool internally- it would be great to get the changes incorporated back into this main open source repository.

There are two main changes:
- Added a flag for only extracting and decoding AndroidManifest.xml (without unpacking resources or sources). We have a use case where all we need are this decoded manifest and the .yml file- this makes the execution significantly faster.
- Added support for duplicate / repeated offsets (for resource entries). There are some built in assumptions in the ARSCDecoder- it assumes that offsets will always be in incrementing order, and that there will be no duplicates. These happen to be true for APK's that are built using standard android tools (aapt, aapt2), but they are not runtime requirements. We've performed some optimizations that result in collapsing certain entries into copies of other entries, which means duplicate offsets will appear (saving APK size).

Example beta build (version 153) of Facebook for Android which requires the 'repeated offsets' fix: https://www.dropbox.com/s/1n3dx7xhelxtik9/fb4a.153-beta.apk?dl=0

Attempting to decode this APK without the fix results in this error:

java -jar ./brut.apktool/apktool-cli/build/libs/apktool-cli-all.jar d -f -o /example_out_dir /path/to/fb4a.153-beta.apk
```
I: Using Apktool 2.3.1-88eed2-SNAPSHOT on fb4a.153-beta.apk
I: Loading resource table...
Exception in thread "main" brut.androlib.AndrolibException: Could not decode arsc file
	at brut.androlib.res.decoder.ARSCDecoder.decode(ARSCDecoder.java:52)
	at brut.androlib.res.AndrolibResources.getResPackagesFromApk(AndrolibResources.java:599)
	at brut.androlib.res.AndrolibResources.loadMainPkg(AndrolibResources.java:73)
	at brut.androlib.res.AndrolibResources.getResTable(AndrolibResources.java:65)
	at brut.androlib.Androlib.getResTable(Androlib.java:68)
	at brut.androlib.ApkDecoder.setTargetSdkVersion(ApkDecoder.java:228)
	at brut.androlib.ApkDecoder.decode(ApkDecoder.java:118)
	at brut.apktool.Main.cmdDecode(Main.java:163)
	at brut.apktool.Main.main(Main.java:72)
Caused by: java.io.IOException: Expected: 0x00000008, got: 0x0000000a
	at brut.util.ExtDataInput.skipCheckShort(ExtDataInput.java:56)
	at brut.androlib.res.decoder.ARSCDecoder.readValue(ARSCDecoder.java:320)
	at brut.androlib.res.decoder.ARSCDecoder.readEntry(ARSCDecoder.java:252)
	at brut.androlib.res.decoder.ARSCDecoder.readTableType(ARSCDecoder.java:231)
	at brut.androlib.res.decoder.ARSCDecoder.readTableTypeSpec(ARSCDecoder.java:156)
	at brut.androlib.res.decoder.ARSCDecoder.readTablePackage(ARSCDecoder.java:118)
	at brut.androlib.res.decoder.ARSCDecoder.readTableHeader(ARSCDecoder.java:80)
	at brut.androlib.res.decoder.ARSCDecoder.decode(ARSCDecoder.java:47)
```
The program executes correctly with the fix applied.
Thanks for your consideration!