### PR TITLE
Prevent "too long" commands on Windows.

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/Androlib.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/Androlib.java
@@ -41,8 +41,6 @@ import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author Ryszard Wiśniewski <brut.alll@gmail.com>
@@ -161,28 +159,15 @@ public class Androlib {
         }
     }
 
-    public void recordUncompressedFiles(ExtFile apkFile, Collection<String> uncompressedFilesOrExts) throws AndrolibException {
+    public void recordUncompressedFiles(ExtFile apkFile, Collection<String> uncompressedFiles) throws AndrolibException {
         try {
             Directory unk = apkFile.getDirectory();
             Set<String> files = unk.getFiles(true);
-            String ext;
 
             for (String file : files) {
                 if (isAPKFileNames(file) && !NO_COMPRESS_PATTERN.matcher(file).find()) {
-                    if (unk.getCompressionLevel(file) == 0) {
-
-                        if (StringUtils.countMatches(file, ".") > 1) {
-                            ext = file;
-                        } else {
-                            ext = FilenameUtils.getExtension(file);
-                            if (ext.isEmpty()) {
-                                ext = file;
-                            }
-                        }
-
-                        if (! uncompressedFilesOrExts.contains(ext)) {
-                            uncompressedFilesOrExts.add(ext);
-                        }
+                    if (unk.getCompressionLevel(file) == 0 && !uncompressedFiles.contains(file)) {
+                        uncompressedFiles.add(file);
                     }
                 }
             }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
@@ -418,7 +418,7 @@ public class ApkDecoder {
 
     private void putFileCompressionInfo(MetaInfo meta) throws AndrolibException {
         if (mUncompressedFiles != null && !mUncompressedFiles.isEmpty()) {
-            meta.doNotCompress = mUncompressedFiles;
+            meta.noCompressAssets = mUncompressedFiles;
         }
     }
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkOptions.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkOptions.java
@@ -28,7 +28,10 @@ public class ApkOptions {
     public boolean isFramework = false;
     public boolean resourcesAreCompressed = false;
     public boolean useAapt2 = false;
+
+    @Deprecated
     public Collection<String> doNotCompress;
+    public Collection<String> noCompressAssets;
 
     public String frameworkFolderLocation = null;
     public String frameworkTag = null;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/meta/MetaInfo.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/meta/MetaInfo.java
@@ -37,7 +37,10 @@ public class MetaInfo {
     public boolean sharedLibrary;
     public boolean sparseResources;
     public Map<String, String> unknownFiles;
+
+    @Deprecated
     public Collection<String> doNotCompress;
+    public Collection<String> noCompressAssets;
 
     private static Yaml getYaml() {
         DumperOptions options = new DumperOptions();

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/BaseTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/BaseTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
 
+import static junit.framework.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
@@ -45,11 +46,11 @@ public class BaseTest {
 
         Map<String, String> controlFiles = control.unknownFiles;
         Map<String, String> testFiles = test.unknownFiles;
-        assertTrue(controlFiles.size() == testFiles.size());
+        assertEquals(controlFiles.size(), testFiles.size());
 
         // Make sure that the compression methods are still the same
         for (Map.Entry<String, String> controlEntry : controlFiles.entrySet()) {
-            assertTrue(controlEntry.getValue().equals(testFiles.get(controlEntry.getKey())));
+            assertEquals(controlEntry.getValue(), testFiles.get(controlEntry.getKey()));
         }
     }
 

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/DoubleExtensionUnknownFileTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/DoubleExtensionUnknownFileTest.java
@@ -62,7 +62,7 @@ public class DoubleExtensionUnknownFileTest extends BaseTest {
         apkDecoder.decode();
 
         MetaInfo metaInfo = new Androlib().readMetaFile(decodedApk);
-        for (String string : metaInfo.doNotCompress) {
+        for (String string : metaInfo.noCompressAssets) {
             if (StringUtils.countMatches(string, ".") > 1) {
                 assertTrue(string.equalsIgnoreCase("assets/bin/Data/sharedassets1.assets.split0"));
             }


### PR DESCRIPTION
We basically work outside aapt and aapt2 with this rewrite. This causes the following:

 - Deprecates "doNotCompress" property as it was vague between extensions and full file paths
 - New property "noCompressAssets" lists files relative to root application of not compressed assets
 - After build of application (aapt2 or aapt1), we copy the application into a new Zip, skipping assets that are not compressed
 - We then copy those assets into the new application, maintaining a stored compression
 - Save application and proceed
 - Fixes #1272 