### PR TITLE
scripts: Regexp for any apktool_*.jar files inside PWD

### DIFF
--- a/scripts/linux/apktool
+++ b/scripts/linux/apktool
@@ -39,7 +39,7 @@ progdir=`pwd`
 prog="${progdir}"/`basename "${prog}"`
 cd "${oldwd}"
 
-jarfile=apktool.jar
+jarfile=$(ls | grep apktool_*.jar)
 libdir="$progdir"
 if [ ! -r "$libdir/$jarfile" ]
 then

--- a/scripts/osx/apktool
+++ b/scripts/osx/apktool
@@ -39,7 +39,7 @@ progdir=`pwd`
 prog="${progdir}"/`basename "${prog}"`
 cd "${oldwd}"
 
-jarfile=apktool.jar
+jarfile=$(ls | grep apktool_*.jar)
 libdir="$progdir"
 if [ ! -r "$libdir/$jarfile" ]
 then

--- a/scripts/windows/apktool.bat
+++ b/scripts/windows/apktool.bat
@@ -2,4 +2,5 @@
 if "%PATH_BASE%" == "" set PATH_BASE=%PATH%
 set PATH=%CD%;%PATH_BASE%;
 chcp 65001 2>nul >nul
-java -jar -Duser.language=en -Dfile.encoding=UTF8 "%~dp0\apktool.jar" %*
+FOR /F "tokens=*" %%a in ('dir /B ^| findstr /R "\<apktool_?*.jar"') do SET JARFILE=%%a
+java -jar -Duser.language=en -Dfile.encoding=UTF8 "%~dp0\%JARFILE%" %*


### PR DESCRIPTION
This means that the user doesn't have to rename the file every time he wants to
update apktool, the new file should be placed inside the directory and the older
one should be deleted.

Tests:
windows: works
linux: works
osx: needs testing (no access to a mac)