### PR TITLE
Force API for recompile

### DIFF
--- a/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
+++ b/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
@@ -230,6 +230,12 @@ public class Main {
         if (cli.hasOption("use-aapt2")) {
             apkOptions.useAapt2 = true;
         }
+        if (cli.hasOption("api")) {
+            apkOptions.forceApi = Integer.parseInt(cli.getOptionValue("api"));
+        }
+        else if (cli.hasOption("api-level")) {
+            apkOptions.forceApi = Integer.parseInt(cli.getOptionValue("api-level"));
+        }
         if (cli.hasOption("o") || cli.hasOption("output")) {
             outFile = new File(cli.getOptionValue("o"));
         } else {

--- a/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
+++ b/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
@@ -230,11 +230,8 @@ public class Main {
         if (cli.hasOption("use-aapt2")) {
             apkOptions.useAapt2 = true;
         }
-        if (cli.hasOption("api")) {
+        if (cli.hasOption("api") || cli.hasOption("api-level")) {
             apkOptions.forceApi = Integer.parseInt(cli.getOptionValue("api"));
-        }
-        else if (cli.hasOption("api-level")) {
-            apkOptions.forceApi = Integer.parseInt(cli.getOptionValue("api-level"));
         }
         if (cli.hasOption("o") || cli.hasOption("output")) {
             outFile = new File(cli.getOptionValue("o"));

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/Androlib.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/Androlib.java
@@ -416,7 +416,7 @@ public class Androlib {
         if (apkOptions.forceBuildAll || isModified(smaliDir, dex)) {
             LOGGER.info("Smaling " + folder + " folder into " + filename + "...");
             dex.delete();
-            SmaliBuilder.build(smaliDir, dex, mMinSdkVersion);
+            SmaliBuilder.build(smaliDir, dex, apkOptions.forceApi > 0 ? apkOptions.forceApi : mMinSdkVersion);
         }
         return true;
     }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
@@ -377,6 +377,25 @@ public class ApkDecoder {
     private void putSdkInfo(MetaInfo meta) throws AndrolibException {
         Map<String, String> info = getResTable().getSdkInfo();
         if (info.size() > 0) {
+            String refValue;
+            if (info.get("minSdkVersion") != null) {
+                refValue = ResXmlPatcher.pullValueFromIntegers(mOutDir, info.get("minSdkVersion"));
+                if (refValue != null) {
+                    info.put("minSdkVersion", refValue);
+                }
+            }
+            if (info.get("targetSdkVersion") != null) {
+                refValue = ResXmlPatcher.pullValueFromIntegers(mOutDir, info.get("targetSdkVersion"));
+                if (refValue != null) {
+                    info.put("targetSdkVersion", refValue);
+                }
+            }
+            if (info.get("maxSdkVersion") != null) {
+                refValue = ResXmlPatcher.pullValueFromIntegers(mOutDir, info.get("maxSdkVersion"));
+                if (refValue != null) {
+                    info.put("maxSdkVersion", refValue);
+                }
+            }
             meta.sdkInfo = info;
         }
     }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkOptions.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkOptions.java
@@ -29,6 +29,7 @@ public class ApkOptions {
     public boolean resourcesAreCompressed = false;
     public boolean useAapt2 = false;
     public boolean noCrunch = false;
+    public int forceApi = 0;
     public Collection<String> doNotCompress;
 
     public String frameworkFolderLocation = null;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/mod/SmaliMod.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/mod/SmaliMod.java
@@ -29,14 +29,14 @@ import org.jf.smali.*;
  */
 public class SmaliMod {
 
-    public static boolean assembleSmaliFile(String smali, DexBuilder dexBuilder, boolean verboseErrors,
+    public static boolean assembleSmaliFile(String smali, DexBuilder dexBuilder, int apiLevel, boolean verboseErrors,
                                             boolean printTokens, File smaliFile) throws IOException, RuntimeException, RecognitionException {
 
         InputStream is = new ByteArrayInputStream(smali.getBytes());
-        return assembleSmaliFile(is, dexBuilder, verboseErrors, printTokens, smaliFile);
+        return assembleSmaliFile(is, dexBuilder, apiLevel, verboseErrors, printTokens, smaliFile);
     }
 
-    public static boolean assembleSmaliFile(InputStream is,DexBuilder dexBuilder, boolean verboseErrors,
+    public static boolean assembleSmaliFile(InputStream is,DexBuilder dexBuilder, int apiLevel, boolean verboseErrors,
                                             boolean printTokens, File smaliFile) throws IOException, RecognitionException {
 
         // copy our filestream into a tmp file, so we don't overwrite
@@ -47,10 +47,10 @@ public class SmaliMod {
         IOUtils.copy(is, os);
         os.close();
 
-        return assembleSmaliFile(tmp,dexBuilder, verboseErrors, printTokens);
+        return assembleSmaliFile(tmp,dexBuilder, apiLevel, verboseErrors, printTokens);
     }
 
-    public static boolean assembleSmaliFile(File smaliFile,DexBuilder dexBuilder, boolean verboseErrors,
+    public static boolean assembleSmaliFile(File smaliFile,DexBuilder dexBuilder, int apiLevel, boolean verboseErrors,
                                             boolean printTokens) throws IOException, RecognitionException {
 
         CommonTokenStream tokens;
@@ -77,6 +77,7 @@ public class SmaliMod {
         }
 
         smaliParser parser = new smaliParser(tokens);
+        parser.setApiLevel(apiLevel);
         parser.setVerboseErrors(verboseErrors);
 
         smaliParser.smali_file_return result = parser.smali_file();
@@ -93,7 +94,7 @@ public class SmaliMod {
         treeStream.setTokenStream(tokens);
 
         smaliTreeWalker dexGen = new smaliTreeWalker(treeStream);
-
+        dexGen.setApiLevel(apiLevel);
         dexGen.setVerboseErrors(verboseErrors);
         dexGen.setDexBuilder(dexBuilder);
         dexGen.smali_file();

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResValueFactory.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResValueFactory.java
@@ -42,7 +42,7 @@ public class ResValueFactory {
                 }
                 return new ResReferenceValue(mPackage, 0, null);
             case TypedValue.TYPE_REFERENCE:
-                return newReference(value, rawValue);
+                return newReference(value, null);
             case TypedValue.TYPE_ATTRIBUTE:
                 return newReference(value, rawValue, true);
             case TypedValue.TYPE_STRING:

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/Res9patchStreamDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/Res9patchStreamDecoder.java
@@ -65,13 +65,21 @@ public class Res9patchStreamDecoder implements ResStreamDecoder {
             drawVLine(im2, w + 1, np.padTop + 1, h - np.padBottom);
 
             int[] xDivs = np.xDivs;
-            for (int i = 0; i < xDivs.length; i += 2) {
-                drawHLine(im2, 0, xDivs[i] + 1, xDivs[i + 1]);
+            if (xDivs.length == 0) {
+                drawHLine(im2, 0, 1, w);
+            } else {
+                for (int i = 0; i < xDivs.length; i += 2) {
+                    drawHLine(im2, 0, xDivs[i] + 1, xDivs[i + 1]);
+                }
             }
 
             int[] yDivs = np.yDivs;
-            for (int i = 0; i < yDivs.length; i += 2) {
-                drawVLine(im2, 0, yDivs[i] + 1, yDivs[i + 1]);
+            if (yDivs.length == 0) {
+                drawVLine(im2, 0, 1, h);
+            } else {
+                for (int i = 0; i < yDivs.length; i += 2) {
+                    drawVLine(im2, 0, yDivs[i] + 1, yDivs[i + 1]);
+                }
             }
 
             // Some images additionally use Optical Bounds

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResXmlPatcher.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResXmlPatcher.java
@@ -198,6 +198,41 @@ public final class ResXmlPatcher {
     }
 
     /**
+     * Finds key in integers.xml file and returns text value
+     *
+     * @param directory Root directory of apk
+     * @param key Integer reference (ie @integer/foo)
+     * @return String|null
+     * @throws AndrolibException
+     */
+    public static String pullValueFromIntegers(File directory, String key) throws AndrolibException {
+        if (key == null || ! key.contains("@")) {
+            return null;
+        }
+
+        File file = new File(directory, "/res/values/integers.xml");
+        key = key.replace("@integer/", "");
+
+        if (file.exists()) {
+            try {
+                Document doc = loadDocument(file);
+                XPath xPath = XPathFactory.newInstance().newXPath();
+                XPathExpression expression = xPath.compile("/resources/integer[@name=" + '"' + key + "\"]/text()");
+
+                Object result = expression.evaluate(doc, XPathConstants.STRING);
+
+                if (result != null) {
+                    return (String) result;
+                }
+
+            }  catch (SAXException | ParserConfigurationException | IOException | XPathExpressionException ignored) {
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Removes attributes like "versionCode" and "versionName" from file.
      *
      * @param file File representing AndroidManifest.xml

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/src/SmaliBuilder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/src/SmaliBuilder.java
@@ -71,7 +71,7 @@ public class SmaliBuilder {
 
         if (fileName.endsWith(".smali")) {
             try {
-                if (!SmaliMod.assembleSmaliFile(inFile, dexBuilder, false, false)) {
+                if (!SmaliMod.assembleSmaliFile(inFile, dexBuilder, mApiLevel, false, false)) {
                     throw new AndrolibException("Could not smali file: " + fileName);
                 }
             } catch (IOException | RecognitionException ex) {


### PR DESCRIPTION
The -api option is currently only available for decompile. However, for framework.jar it is necessary to both decompile **and** recompile using "-api 28" in order to produce a proper dex (and avoid a bootloop), something we had to do with smali.jar as a workaround.
This modification adds the -api option to recompile.