### PR TITLE
Bug with parsing Android Binary XML when the strings are UTF16 fixed

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
@@ -342,10 +342,10 @@ public class StringBlock {
             int high = (array[offset + 3] & 0xFF) << 8;
             int low = (array[offset + 2] & 0xFF);
             int len_value =  ((val & 0x7FFF) << 16) + (high + low);
-            return new int[] {4, len_value * 2};
+            return new int[] {offset + 4, len_value * 2};
             
         }
-        return new int[] {2, val * 2};
+        return new int[] {offset + 2, val * 2};
     }
 
     private int[] m_stringOffsets;


### PR DESCRIPTION
I noticed that in comparison to the getUtf8 function in the StringBlock.java file getUtf16 function provides resulting offset relative to initial offset instead of one computed on the basis of the initial offset. This would make the UTF16 decoder always start from offset 2 or 4