### PR TITLE
Fix documentation description for --use-aapt2

### DIFF
--- a/_includes/options-rebuild.md
+++ b/_includes/options-rebuild.md
@@ -19,5 +19,5 @@ These are all the options when building an apk.
 <blockquote>The location where framework files are loaded from</blockquote>
 <br />
 <strong><kbd>--use-aapt2</kbd> - <span class="label label-success">v2.3.2</span></strong>
-<blockquote>The location where framework files are loaded from</blockquote>
+<blockquote>Use the aapt2 binary instead of appt</blockquote>
 <br />


### PR DESCRIPTION
Currently, the description for the --use-aapt2 argument is a copy of
another argument's description, which is wrong. This patch changes
the description to "Use the aapt2 binary instead of appt".