### PR TITLE
[Bugfix][Security] Fix for zip slip

### DIFF
--- a/brut.j.dir/src/main/java/brut/directory/Directory.java
+++ b/brut.j.dir/src/main/java/brut/directory/Directory.java
@@ -57,5 +57,5 @@ public interface Directory {
 
     public void close() throws IOException;
     
-    public final char separator = '/';
+    public final char separator = File.separatorChar;
 }


### PR DESCRIPTION
Due to the file character separator mentioned as '/' which works fine for *nix env but not for windows that can bypass windows file separator '\\\\' and write to arbitrary location escaping the unzip directory that can lead to RCE. This fix is particularly for addressing windows.

Reproduction steps: Just add file name ..\\\\..\\\\startup.exe inside assets folder of the apk file which bypasses and writes above the root directory.

i'm open for edge cases that can be committed to the same pull request

[Edit:  Didn't know github would have escaped the backslash ]