### PR TITLE
Make apktool Linux script automatically build the library

### DIFF
--- a/scripts/linux/apktool
+++ b/scripts/linux/apktool
@@ -43,8 +43,14 @@ jarfile=apktool.jar
 libdir="$progdir"
 if [ ! -r "$libdir/$jarfile" ]
 then
-    echo `basename "$prog"`": can't find $jarfile"
-    exit 1
+    echo `basename "$prog"`": can't find $jarfile, attempting to build from source"
+	pushd .
+	cd "${progdir}/../.."
+	./gradlew build shadowJar
+	if [ $? -ne 0 ]
+	then
+		exit 1
+	fi
 fi
 
 javaOpts=""

--- a/scripts/linux/apktool.jar
+++ b/scripts/linux/apktool.jar
@@ -1,0 +1,1 @@
+../../brut.apktool/apktool-cli/build/libs/apktool-cli-all.jar


### PR DESCRIPTION
This allows people to just clone the repo and put "scripts/linux" in
their PATH to run apktool. And you can now put up a "quickstart" section
in your `README.md` which tells people to run "./scripts/linux/apktool" after cloning
the repository.

Signed-off-by: Florian Schmaus <flo@geekplace.eu>