### PR TITLE
Enhanced Windows wrapper script

### DIFF
--- a/scripts/windows/apktool.bat
+++ b/scripts/windows/apktool.bat
@@ -1,5 +1,36 @@
 @echo off
-if "%PATH_BASE%" == "" set PATH_BASE=%PATH%
-set PATH=%CD%;%PATH_BASE%;
+setlocal
+set BASENAME=apktool_
 chcp 65001 2>nul >nul
-java -jar -Duser.language=en -Dfile.encoding=UTF8 "%~dp0\apktool.jar" %*
+
+rem Find the highest version .jar available in the same directory as the script
+setlocal EnableDelayedExpansion
+pushd "%~dp0"
+if exist apktool.jar (
+    set BASENAME=apktool
+    goto skipversioned
+)
+set max=0
+for /f "tokens=1* delims=-_.0" %%A in ('dir /b /a-d %BASENAME%*.jar') do if %%~B gtr !max! set max=%%~nB
+:skipversioned
+popd
+setlocal DisableDelayedExpansion
+
+rem Find out if the commandline is a parameterless .jar or directory, for fast unpack/repack
+if "%~1"=="" goto load
+if not "%~2"=="" goto load
+set ATTR=%~a1
+if "%ATTR:~0,1%"=="d" (
+    rem Directory, rebuild
+    set fastCommand=b
+)
+if "%ATTR:~0,1%"=="-" if "%~x1"==".apk" (
+    rem APK file, unpack
+    set fastCommand=d
+)
+
+:load
+java -jar -Duser.language=en -Dfile.encoding=UTF8 "%~dp0%BASENAME%%max%.jar" %fastCommand% %*
+
+rem Pause when ran non interactively
+for /f "tokens=2" %%# in ("%cmdcmdline%") do if /i "%%#" equ "/c" pause


### PR DESCRIPTION
I added a bit of functionality to the apktool wrapper script and thought I'd share. This has several advantages compared to the base currently available:

1. No environment pollution
2. Automatic pick of the latest version, without the need to rename
3. Supports command-less calls, if the only parameter is a directory or an apk
    * Supports drag & drop
    * Supports double-click
    * Supports "Send to" functionality
4. Pauses when ran non interactively, so the prompt doesn't automatically close

If the script finds an `apktool.jar` it's selected automatically, otherwise it looks for jar versions available in its directory with the name format `apktool_<version>.jar` and picks the latest accordingly.

With drag & drop, send-tos and calls:
* if the parameter is an apk file, the script issues the `d` command
* if the parameter is a directory, the script issues the `b` command