### PR TITLE
build: update to smali/baksmali 2.3.4

### DIFF
--- a/brut.apktool/apktool-cli/build.gradle
+++ b/brut.apktool/apktool-cli/build.gradle
@@ -49,6 +49,7 @@ task proguard(type: proguard.gradle.ProGuardTask, dependsOn: shadowJar) {
         libraryjars "${System.properties['java.home']}/lib/rt.jar"
     } else {
         libraryjars "${System.properties['java.home']}/jmods/java.base.jmod", jarfilter: '!**.jar', filter: '!module-info.class'
+        libraryjars "${System.properties['java.home']}/jmods/java.compiler.jmod", jarfilter: '!**.jar', filter: '!module-info.class'
         libraryjars "${System.properties['java.home']}/jmods/java.logging.jmod", jarfilter: '!**.jar', filter: '!module-info.class'
         libraryjars "${System.properties['java.home']}/jmods/java.xml.jmod", jarfilter: '!**.jar', filter: '!module-info.class'
         libraryjars "${System.properties['java.home']}/jmods/java.desktop.jmod", jarfilter: '!**.jar', filter: '!module-info.class'

--- a/brut.apktool/apktool-cli/build.gradle
+++ b/brut.apktool/apktool-cli/build.gradle
@@ -45,6 +45,7 @@ task proguard(type: proguard.gradle.ProGuardTask, dependsOn: shadowJar) {
 
     // Java 9 and prior uses merged package for runtime, later uses split jmod files.
     if (JavaVersion.current() <= JavaVersion.VERSION_1_8) {
+        libraryjars "${System.properties['java.home']}/lib/jce.jar"
         libraryjars "${System.properties['java.home']}/lib/rt.jar"
     } else {
         libraryjars "${System.properties['java.home']}/jmods/java.base.jmod", jarfilter: '!**.jar', filter: '!module-info.class'

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/mod/SmaliMod.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/mod/SmaliMod.java
@@ -59,7 +59,7 @@ public class SmaliMod {
         InputStream is = new FileInputStream(smaliFile);
         InputStreamReader reader = new InputStreamReader(is, "UTF-8");
 
-        lexer = new smaliFlexLexer(reader);
+        lexer = new smaliFlexLexer(reader, apiLevel);
         ((smaliFlexLexer)lexer).setSourceFile(smaliFile);
         tokens = new CommonTokenStream((TokenSource) lexer);
 

--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ subprojects {
 
     ext {
         depends = [
-                baksmali: 'org.smali:baksmali:2.3',
+                baksmali: 'org.smali:baksmali:2.3.4',
                 commons_cli: 'commons-cli:commons-cli:1.4',
                 commons_io: 'commons-io:commons-io:2.4',
                 commons_lang: 'org.apache.commons:commons-lang3:3.1',
@@ -117,7 +117,7 @@ subprojects {
                 junit: 'junit:junit:4.12',
                 proguard_gradle: 'net.sf.proguard:proguard-gradle:6.1.1',
                 snakeyaml: 'org.yaml:snakeyaml:1.18:android',
-                smali: 'org.smali:smali:2.3',
+                smali: 'org.smali:smali:2.3.4',
                 xmlpull: 'xpp3:xpp3:1.1.4c',
                 xmlunit: 'xmlunit:xmlunit:1.6',
         ]


### PR DESCRIPTION
API level now has to be specified in smaliFlexLexer constructor, won't compile otherwise.
https://github.com/JesusFreke/smali/commit/209ba3b0a6d5fc50ffbf0d2462ec195ed24204be