### PR TITLE
Fix AXML parser to handle obfuscated attribute names

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AXmlResourceParser.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AXmlResourceParser.java
@@ -339,13 +339,12 @@ public class AXmlResourceParser implements XmlResourceParser {
 
         // some attributes will return "", we must rely on the resource_id and refer to the frameworks
         // to match the resource id to the name. ex: 0x101021C = versionName
-        if (value.length() != 0) {
+        if (value.length() != 0 && !android_ns.equals(getAttributeNamespace(index))) {
             return value;
         } else {
             try {
                 value = mAttrDecoder.decodeManifestAttr(getAttributeNameResource(index));
             } catch (AndrolibException e) {
-                value = "";
             }
             return value;
         }


### PR DESCRIPTION
This adds an additional check if the attribute namespace belongs to Android namespace, and if so we try to decode using attribute decoder.

If `decodeManifestAttr` throws an exception, we want to use the original `value`. Note that if `value.length() == 0`, then the `value` is already the empty string.

We found this issue and resolved it during the effort of de-obfuscating obfuscated APKs.
Please see Project BAOBAB for details: https://github.com/theori-io/POC2019-BAOBAB