### PR TITLE
fix/uncompressed_files_bug

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/Androlib.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/Androlib.java
@@ -169,14 +169,12 @@ public class Androlib {
 
             for (String file : files) {
                 if (isAPKFileNames(file) &&
-                    unk.getCompressionLevel(file) == 0 &&
-                    unk.getSize(file) != 0) {
+                        unk.getCompressionLevel(file) == 0 &&
+                        unk.getSize(file) != 0) {
 
                     ext = FilenameUtils.getExtension(file);
 
-                    // If we don't have a png extension, but we have multiple "dots", we may have another iteration
-                    // of OEM specific 9patch files. We need to record full path for these.
-                    if (ext.isEmpty() || (!ext.equals("png") && StringUtils.countMatches(file, ".") > 1)) {
+                    if (ext.isEmpty() || !NO_COMPRESS_PATTERN.matcher(ext).find()) {
                         ext = file;
                     }
                     if (!uncompressedFilesOrExts.contains(ext)) {
@@ -485,7 +483,7 @@ public class Androlib {
                     ninePatch = null;
                 }
                 mAndRes.aaptPackage(apkFile, new File(appDir,
-                        "AndroidManifest.xml"), new File(appDir, "res"),
+                                "AndroidManifest.xml"), new File(appDir, "res"),
                         ninePatch, null, parseUsesFramework(usesFramework));
 
                 Directory tmpDir = new ExtFile(apkFile).getDirectory();
@@ -547,7 +545,7 @@ public class Androlib {
                 }
 
                 mAndRes.aaptPackage(apkFile, new File(appDir,
-                        "AndroidManifest.xml"), null, ninePatch, null,
+                                "AndroidManifest.xml"), null, ninePatch, null,
                         parseUsesFramework(usesFramework));
 
                 Directory tmpDir = new ExtFile(apkFile).getDirectory();
@@ -796,4 +794,7 @@ public class Androlib {
     private final static String[] APK_STANDARD_ALL_FILENAMES = new String[] {
             "classes.dex", "AndroidManifest.xml", "resources.arsc", "res", "r", "R",
             "lib", "libs", "assets", "META-INF", "kotlin" };
+    private final static Pattern NO_COMPRESS_PATTERN = Pattern.compile("(" +
+            "jpg|jpeg|png|gif|wav|mp2|mp3|ogg|aac|mpg|mpeg|mid|midi|smf|jet|rtttl|imy|xmf|mp4|" +
+            "m4a|m4v|3gp|3gpp|3g2|3gpp2|amr|awb|wma|wmv|webm|mkv)$");
 }


### PR DESCRIPTION
there files should not be compressed:
1.base on AOSP's frameworks/base/tools/aapt/Package.cpp: NO_COMPRESS_PATTERN = Pattern.compile("(jpg|jpeg|png|gif|wav|mp2|mp3|ogg|aac|mpg|mpeg|mid|midi|smf|jet|rtttl|imy|xmf|mp4|" +
            "m4a|m4v|3gp|3gpp|3g2|3gpp2|amr|awb|wma|wmv|webm|mkv)$"); specifically this rule include 9patch files.
2.file has not ext
3.the compressive type is store

warning:
even if there are the same type of files, they are compressive type may different, just like this example:
-rw----     1.0 fat     8343 b-  0% stor 80-Jan-01 08:00 assets/resources/assets/effect/common/ctp_trail15_1_tex.unity3d
-rw----     1.0 fat    11526 b-  0% stor 80-Jan-01 08:00 assets/resources/assets/effect/common/ctp_trail15_tex.unity3d
-rw----     2.0 fat     2483 bl 19% defN 80-Jan-01 08:00 assets/resources/assets/effect/common/cw_310300_cylq_ql01_mat.unity3d
-rw----     2.0 fat     9467 bl 17% defN 80-Jan-01 08:00 assets/resources/assets/effect/common/cw_310300_cylq_ql03_fbx.unity3d
ctp_trail15_1_tex.unity3d and ctp_trail15_tex.unity3d are uncompressed, but cw_310300_cylq_ql01_mat.unity3d and cw_310300_cylq_ql03_fbx.unity3d are compressed.

That is why I modified recordUncompressedFiles Method.