### PR TITLE
Issue dex

### DIFF
--- a/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
+++ b/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
@@ -149,6 +149,10 @@ public class Main {
         if (cli.hasOption("api") || cli.hasOption("api-level")) {
             decoder.setApi(Integer.parseInt(cli.getOptionValue("api")));
         }
+        // 是否递归解压dex，包括asset等文件夹中的dex
+        if (cli.hasOption("recursive") || cli.hasOption("dex-recursive")) {
+            decoder.setRecursive(true);
+        }
         if (cli.hasOption("o") || cli.hasOption("output")) {
             outDir = new File(cli.getOptionValue("o"));
             decoder.setOutDir(outDir);

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
@@ -152,7 +152,9 @@ public class ApkDecoder {
 
             if (hasMultipleSources()) {
                 // foreach unknown dex file in root, lets disassemble it
-                Set<String> files = mApkFile.getDirectory().getFiles(true);
+                // 修改：是否迭代解压，这里修改为False，因为在添加OAid的获取后，移动联盟的aar包中，assets里有dex文件。
+                // 不可且不需要反编译，如果迭代就会导致代码去反编译这个文件
+                Set<String> files = mApkFile.getDirectory().getFiles(false);
                 for (String file : files) {
                     if (file.endsWith(".dex")) {
                         if (! file.equalsIgnoreCase("classes.dex")) {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
@@ -1,18 +1,18 @@
 /**
- *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
- *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
+ * Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package brut.androlib;
 
@@ -26,10 +26,10 @@ import brut.androlib.meta.VersionInfo;
 import brut.androlib.res.AndrolibResources;
 import brut.androlib.res.data.ResPackage;
 import brut.androlib.res.data.ResTable;
-import brut.directory.ExtFile;
 import brut.androlib.res.xml.ResXmlPatcher;
 import brut.common.BrutException;
 import brut.directory.DirectoryException;
+import brut.directory.ExtFile;
 import brut.util.OS;
 import com.google.common.base.Strings;
 
@@ -42,6 +42,35 @@ import java.util.logging.Logger;
  * @author Ryszard Wiśniewski <brut.alll@gmail.com>
  */
 public class ApkDecoder {
+    public final static short DECODE_SOURCES_NONE = 0x0000;
+    public final static short DECODE_SOURCES_SMALI = 0x0001;
+    public final static short DECODE_SOURCES_SMALI_ONLY_MAIN_CLASSES = 0x0010;
+    public final static short DECODE_RESOURCES_NONE = 0x0100;
+    public final static short DECODE_RESOURCES_FULL = 0x0101;
+    public final static short FORCE_DECODE_MANIFEST_NONE = 0x0000;
+    public final static short FORCE_DECODE_MANIFEST_FULL = 0x0001;
+    public final static short DECODE_ASSETS_NONE = 0x0000;
+    public final static short DECODE_ASSETS_FULL = 0x0001;
+    private final static Logger LOGGER = Logger.getLogger(Androlib.class.getName());
+    private final Androlib mAndrolib;
+    private ExtFile mApkFile;
+    private File mOutDir;
+    private ResTable mResTable;
+    private short mDecodeSources = DECODE_SOURCES_SMALI;
+    private short mDecodeResources = DECODE_RESOURCES_FULL;
+    private short mForceDecodeManifest = FORCE_DECODE_MANIFEST_NONE;
+    private short mDecodeAssets = DECODE_ASSETS_FULL;
+    private boolean mForceDelete = false;
+    private boolean mKeepBrokenResources = false;
+    private boolean mBakDeb = true;
+    private Collection<String> mUncompressedFiles;
+    private boolean mAnalysisMode = false;
+    private int mApi = 15;
+    /**
+     * 是否递归解压dex，默认为否
+     */
+    private boolean recursive = false;
+
     public ApkDecoder() {
         this(new Androlib());
     }
@@ -49,11 +78,9 @@ public class ApkDecoder {
     public ApkDecoder(Androlib androlib) {
         mAndrolib = androlib;
     }
-
     public ApkDecoder(File apkFile) {
         this(apkFile, new Androlib());
     }
-
     public ApkDecoder(File apkFile, Androlib androlib) {
         mAndrolib = androlib;
         setApkFile(apkFile);
@@ -63,19 +90,20 @@ public class ApkDecoder {
         if (mApkFile != null) {
             try {
                 mApkFile.close();
-            } catch (IOException ignored) {}
+            } catch (IOException ignored) {
+            }
         }
 
         mApkFile = new ExtFile(apkFile);
         mResTable = null;
     }
 
-    public void setOutDir(File outDir) throws AndrolibException {
-        mOutDir = outDir;
-    }
-
     public void setApi(int api) {
         mApi = api;
+    }
+
+    public void setRecursive(boolean recursive) {
+        this.recursive = recursive;
     }
 
     public void decode() throws AndrolibException, IOException, DirectoryException {
@@ -131,8 +159,7 @@ public class ApkDecoder {
                     if (mDecodeResources == DECODE_RESOURCES_FULL
                             || mForceDecodeManifest == FORCE_DECODE_MANIFEST_FULL) {
                         mAndrolib.decodeManifestFull(mApkFile, outDir, getResTable());
-                    }
-                    else {
+                    } else {
                         mAndrolib.decodeManifestRaw(mApkFile, outDir);
                     }
                 }
@@ -154,11 +181,11 @@ public class ApkDecoder {
                 // foreach unknown dex file in root, lets disassemble it
                 // 修改：是否迭代解压，这里修改为False，因为在添加OAid的获取后，移动联盟的aar包中，assets里有dex文件。
                 // 不可且不需要反编译，如果迭代就会导致代码去反编译这个文件
-                Set<String> files = mApkFile.getDirectory().getFiles(false);
+                Set<String> files = mApkFile.getDirectory().getFiles(recursive);
                 for (String file : files) {
                     if (file.endsWith(".dex")) {
-                        if (! file.equalsIgnoreCase("classes.dex")) {
-                            switch(mDecodeSources) {
+                        if (!file.equalsIgnoreCase("classes.dex")) {
+                            switch (mDecodeSources) {
                                 case DECODE_SOURCES_NONE:
                                     mAndrolib.decodeSourcesRaw(mApkFile, outDir, file);
                                     break;
@@ -189,7 +216,8 @@ public class ApkDecoder {
         } finally {
             try {
                 mApkFile.close();
-            } catch (IOException ignored) {}
+            } catch (IOException ignored) {
+            }
         }
     }
 
@@ -221,7 +249,7 @@ public class ApkDecoder {
         mDecodeAssets = mode;
     }
 
-    public void setAnalysisMode(boolean mode, boolean pass) throws AndrolibException{
+    public void setAnalysisMode(boolean mode, boolean pass) throws AndrolibException {
         mAnalysisMode = mode;
 
         // only set mResTable, once it exists
@@ -268,7 +296,7 @@ public class ApkDecoder {
         if (mResTable == null) {
             boolean hasResources = hasResources();
             boolean hasManifest = hasManifest();
-            if (! (hasManifest || hasResources)) {
+            if (!(hasManifest || hasResources)) {
                 throw new AndrolibException(
                         "Apk doesn't contain either AndroidManifest.xml file or resources.arsc file");
             }
@@ -290,7 +318,7 @@ public class ApkDecoder {
             Set<String> files = mApkFile.getDirectory().getFiles(false);
             for (String file : files) {
                 if (file.endsWith(".dex")) {
-                    if (! file.equalsIgnoreCase("classes.dex")) {
+                    if (!file.equalsIgnoreCase("classes.dex")) {
                         return true;
                     }
                 }
@@ -324,24 +352,15 @@ public class ApkDecoder {
         }
     }
 
-    public final static short DECODE_SOURCES_NONE = 0x0000;
-    public final static short DECODE_SOURCES_SMALI = 0x0001;
-    public final static short DECODE_SOURCES_SMALI_ONLY_MAIN_CLASSES = 0x0010;
-
-    public final static short DECODE_RESOURCES_NONE = 0x0100;
-    public final static short DECODE_RESOURCES_FULL = 0x0101;
-
-    public final static short FORCE_DECODE_MANIFEST_NONE = 0x0000;
-    public final static short FORCE_DECODE_MANIFEST_FULL = 0x0001;
-
-    public final static short DECODE_ASSETS_NONE = 0x0000;
-    public final static short DECODE_ASSETS_FULL = 0x0001;
-
     private File getOutDir() throws AndrolibException {
         if (mOutDir == null) {
             throw new AndrolibException("Out dir not set");
         }
         return mOutDir;
+    }
+
+    public void setOutDir(File outDir) throws AndrolibException {
+        mOutDir = outDir;
     }
 
     private void writeMetaFile() throws AndrolibException {
@@ -418,7 +437,8 @@ public class ApkDecoder {
         int id = getResTable().getPackageId();
         try {
             id = getResTable().getPackage(renamed).getId();
-        } catch (UndefinedResObject ignored) {}
+        } catch (UndefinedResObject ignored) {
+        }
 
         if (Strings.isNullOrEmpty(original)) {
             return;
@@ -459,22 +479,4 @@ public class ApkDecoder {
     private void putSharedLibraryInfo(MetaInfo meta) throws AndrolibException {
         meta.sharedLibrary = mResTable.getSharedLibrary();
     }
-
-    private final Androlib mAndrolib;
-
-    private final static Logger LOGGER = Logger.getLogger(Androlib.class.getName());
-
-    private ExtFile mApkFile;
-    private File mOutDir;
-    private ResTable mResTable;
-    private short mDecodeSources = DECODE_SOURCES_SMALI;
-    private short mDecodeResources = DECODE_RESOURCES_FULL;
-    private short mForceDecodeManifest = FORCE_DECODE_MANIFEST_NONE;
-    private short mDecodeAssets = DECODE_ASSETS_FULL;
-    private boolean mForceDelete = false;
-    private boolean mKeepBrokenResources = false;
-    private boolean mBakDeb = true;
-    private Collection<String> mUncompressedFiles;
-    private boolean mAnalysisMode = false;
-    private int mApi = 15;
 }


### PR DESCRIPTION
因为`Android 10` 不允许设备获取`imei`，所以，设备厂商推出获取`oaid`作为替代方案，但是在接入获取设备id的SDK包以后， `apktool`解压时发生错误，意为在`asset`下有一个 `A3AEECD8.dex` 的文件，并不能被反编译，而且也不需要反编译。

所以我做了修改，默认不进行递归解压，在一般情况下，只需要反编译根目录下的 `classes.dex` 即可。

还有我使用了idea的代码格式化工具，导致项目代码的一些顺序发生了变化。重点在184行。望采纳。