### PR TITLE
Update Gradle Wrapper and license plugin

### DIFF
--- a/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
+++ b/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/Androlib.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/Androlib.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/AndrolibException.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/AndrolibException.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkOptions.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApktoolProperties.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApktoolProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/err/AXmlDecodingException.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/err/AXmlDecodingException.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/err/CantFind9PatchChunk.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/err/CantFind9PatchChunk.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/err/CantFindFrameworkResException.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/err/CantFindFrameworkResException.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/err/InFileNotFoundException.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/err/InFileNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/err/OutDirExistsException.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/err/OutDirExistsException.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/err/RawXmlEncounteredException.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/err/RawXmlEncounteredException.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/err/UndefinedResObject.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/err/UndefinedResObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/meta/MetaInfo.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/meta/MetaInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/meta/PackageInfo.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/meta/PackageInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/meta/StringExConstructor.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/meta/StringExConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/meta/StringExRepresent.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/meta/StringExRepresent.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/meta/UsesFramework.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/meta/UsesFramework.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/meta/VersionInfo.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/meta/VersionInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/meta/YamlStringEscapeUtils.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/meta/YamlStringEscapeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/mod/SmaliMod.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/mod/SmaliMod.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResConfigFlags.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResConfigFlags.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResID.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResID.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResPackage.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResPackage.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResResSpec.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResResSpec.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResResource.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResTable.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResType.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResType.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResTypeSpec.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResTypeSpec.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResUnknownFiles.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResUnknownFiles.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResValuesFile.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResValuesFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResArrayValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResArrayValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResAttr.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResAttr.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResBagValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResBagValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResBoolValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResBoolValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResColorValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResColorValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResDimenValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResDimenValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResEmptyValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResEmptyValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResEnumAttr.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResEnumAttr.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResFileValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResFileValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResFlagsAttr.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResFlagsAttr.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResFloatValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResFloatValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResFractionValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResFractionValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResIdValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResIdValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResIntBasedValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResIntBasedValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResIntValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResIntValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResPluralsValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResPluralsValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResReferenceValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResReferenceValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResScalarValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResScalarValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResStringValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResStringValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResStyleValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResStyleValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResValueFactory.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResValueFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AXmlResourceParser.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AXmlResourceParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/Res9patchStreamDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/Res9patchStreamDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResAttrDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResAttrDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResFileDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResFileDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResRawStreamDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResRawStreamDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResStreamDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResStreamDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResStreamDecoderContainer.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResStreamDecoderContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/XmlPullStreamDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/XmlPullStreamDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/util/ExtFile.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/util/ExtFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/util/ExtMXSerializer.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/util/ExtMXSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/util/ExtXmlSerializer.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/util/ExtXmlSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResValuesXmlSerializable.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResValuesXmlSerializable.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResXmlEncodable.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResXmlEncodable.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResXmlEncoders.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResXmlEncoders.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResXmlPatcher.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResXmlPatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/src/SmaliBuilder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/src/SmaliBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/src/SmaliDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/src/SmaliDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/main/java/org/xmlpull/renamed/MXSerializer.java
+++ b/brut.apktool/apktool-lib/src/main/java/org/xmlpull/renamed/MXSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/BaseTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/BaseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/TestUtils.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/TestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/AndroidOreoNotSparseTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/AndroidOreoNotSparseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/AndroidOreoSparseTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/AndroidOreoSparseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/BuildAndDecodeJarTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/BuildAndDecodeJarTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/BuildAndDecodeTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/BuildAndDecodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/DebugTagRetainedTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/DebugTagRetainedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/DefaultBaksmaliVariableTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/DefaultBaksmaliVariableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/EmptyResourcesArscTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/EmptyResourcesArscTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/LargeIntsInManifestTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/LargeIntsInManifestTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/ProviderAttributeTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/ProviderAttributeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/ReferenceVersionCodeTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/ReferenceVersionCodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/SharedLibraryTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/SharedLibraryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/SkipAssetTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/SkipAssetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/UnknownCompressionTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/UnknownCompressionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/BuildAndDecodeTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/BuildAndDecodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/NonStandardPkgIdTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/NonStandardPkgIdTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/androlib/InvalidSdkBoundingTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/androlib/InvalidSdkBoundingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/AndResGuardTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/AndResGuardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/DecodeArrayTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/DecodeArrayTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/DecodeKotlinCoroutinesTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/DecodeKotlinCoroutinesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/DecodeKotlinTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/DecodeKotlinTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/DoubleExtensionUnknownFileTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/DoubleExtensionUnknownFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/DuplicateDexTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/DuplicateDexTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/Empty9PatchTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/Empty9PatchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/ExternalEntityTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/ExternalEntityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/ForceManifestDecodeNoResourcesTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/ForceManifestDecodeNoResourcesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/MinifiedArscTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/MinifiedArscTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/MissingDiv9PatchTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/MissingDiv9PatchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/MissingVersionManifestTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/MissingVersionManifestTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/OutsideOfDirectoryEntryTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/OutsideOfDirectoryEntryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/ParentDirectoryTraversalTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/ParentDirectoryTraversalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/VectorDrawableTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/VectorDrawableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/encoders/PositionalEnumerationTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/encoders/PositionalEnumerationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/util/AaptVersionTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/util/AaptVersionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/util/UnknownDirectoryTraversalTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/util/UnknownDirectoryTraversalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.j.common/src/main/java/brut/common/BrutException.java
+++ b/brut.j.common/src/main/java/brut/common/BrutException.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.j.common/src/main/java/brut/common/InvalidUnknownFileException.java
+++ b/brut.j.common/src/main/java/brut/common/InvalidUnknownFileException.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.j.common/src/main/java/brut/common/RootUnknownFileException.java
+++ b/brut.j.common/src/main/java/brut/common/RootUnknownFileException.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.j.common/src/main/java/brut/common/TraversalUnknownFileException.java
+++ b/brut.j.common/src/main/java/brut/common/TraversalUnknownFileException.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.j.dir/src/main/java/brut/directory/AbstractDirectory.java
+++ b/brut.j.dir/src/main/java/brut/directory/AbstractDirectory.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.j.dir/src/main/java/brut/directory/DirUtil.java
+++ b/brut.j.dir/src/main/java/brut/directory/DirUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.j.dir/src/main/java/brut/directory/Directory.java
+++ b/brut.j.dir/src/main/java/brut/directory/Directory.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.j.dir/src/main/java/brut/directory/DirectoryException.java
+++ b/brut.j.dir/src/main/java/brut/directory/DirectoryException.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.j.dir/src/main/java/brut/directory/ExtFile.java
+++ b/brut.j.dir/src/main/java/brut/directory/ExtFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.j.dir/src/main/java/brut/directory/FileDirectory.java
+++ b/brut.j.dir/src/main/java/brut/directory/FileDirectory.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.j.dir/src/main/java/brut/directory/PathAlreadyExists.java
+++ b/brut.j.dir/src/main/java/brut/directory/PathAlreadyExists.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.j.dir/src/main/java/brut/directory/PathNotExist.java
+++ b/brut.j.dir/src/main/java/brut/directory/PathNotExist.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.j.dir/src/main/java/brut/directory/ZipRODirectory.java
+++ b/brut.j.dir/src/main/java/brut/directory/ZipRODirectory.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.j.dir/src/main/java/brut/directory/ZipUtils.java
+++ b/brut.j.dir/src/main/java/brut/directory/ZipUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.j.util/src/main/java/brut/util/AaptManager.java
+++ b/brut.j.util/src/main/java/brut/util/AaptManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.j.util/src/main/java/brut/util/BrutIO.java
+++ b/brut.j.util/src/main/java/brut/util/BrutIO.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.j.util/src/main/java/brut/util/DataInputDelegate.java
+++ b/brut.j.util/src/main/java/brut/util/DataInputDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.j.util/src/main/java/brut/util/Duo.java
+++ b/brut.j.util/src/main/java/brut/util/Duo.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.j.util/src/main/java/brut/util/ExtDataInput.java
+++ b/brut.j.util/src/main/java/brut/util/ExtDataInput.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.j.util/src/main/java/brut/util/Jar.java
+++ b/brut.j.util/src/main/java/brut/util/Jar.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.j.util/src/main/java/brut/util/OS.java
+++ b/brut.j.util/src/main/java/brut/util/OS.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/brut.j.util/src/main/java/brut/util/OSDetection.java
+++ b/brut.j.util/src/main/java/brut/util/OSDetection.java
@@ -1,4 +1,4 @@
-/**
+/*
  *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
  *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
  *

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
 }
 
 plugins {
-    id "com.github.hierynomus.license" version "0.14.0"
+    id "com.github.hierynomus.license" version "0.15.0"
 }
 
 apply from: 'gradle/functions.gradle'
@@ -47,6 +47,9 @@ allprojects {
         exclude "**/android/content/res/*.java"
         exclude "**/android/util/*.java"
         include "**/*.java"
+        mapping {
+            java='SLASHSTAR_STYLE'
+        }
         strictCheck true
 
         ext.year = Calendar.getInstance().get(Calendar.YEAR)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
A couple of quick updates here:

- Gradle Wrapper `5.6.4`
- hierynomus license Gradle plugin `0.15.0`

In a separate commit it fixes several file header comments which previously had Javadoc style.