### PR TITLE
fix the usage of debug flag (-d) when using aapt2 (issue #2328)

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/Androlib.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/Androlib.java
@@ -466,7 +466,12 @@ public class Androlib {
                 LOGGER.info("Building resources...");
 
                 if (apkOptions.debugMode) {
-                    ResXmlPatcher.removeApplicationDebugTag(new File(appDir, "AndroidManifest.xml"));
+                    if (apkOptions.isAapt2()) {
+                        LOGGER.info("Using aapt2 - setting 'debuggable' attribute to 'true' in AndroidManifest.xml");
+                        ResXmlPatcher.setApplicationDebugTagTrue(new File(appDir, "AndroidManifest.xml"));
+                    } else {
+                        ResXmlPatcher.removeApplicationDebugTag(new File(appDir, "AndroidManifest.xml"));
+                    }
                 }
 
                 File apkFile = File.createTempFile("APKTOOL", null);

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResXmlPatcher.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResXmlPatcher.java
@@ -35,10 +35,7 @@ import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
-import org.w3c.dom.Document;
-import org.w3c.dom.NamedNodeMap;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
+import org.w3c.dom.*;
 import org.xml.sax.SAXException;
 
 import brut.androlib.AndrolibException;
@@ -68,6 +65,37 @@ public final class ResXmlPatcher {
                 if (debugAttr != null) {
                     attr.removeNamedItem("android:debuggable");
                 }
+
+                saveDocument(file, doc);
+
+            } catch (SAXException | ParserConfigurationException | IOException | TransformerException ignored) {
+            }
+        }
+    }
+
+    /**
+     * Sets "debug" tag in the file to true
+     *
+     * @param file AndroidManifest file
+     * @throws AndrolibException
+     */
+    public static void setApplicationDebugTagTrue(File file) throws AndrolibException {
+        if (file.exists()) {
+            try {
+                Document doc = loadDocument(file);
+                Node application = doc.getElementsByTagName("application").item(0);
+
+                // load attr
+                NamedNodeMap attr = application.getAttributes();
+                Node debugAttr = attr.getNamedItem("android:debuggable");
+
+                if (debugAttr == null) {
+                    debugAttr = doc.createAttribute("android:debuggable");
+                    attr.setNamedItem(debugAttr);
+                }
+
+                // set application:debuggable to 'true
+                debugAttr.setNodeValue("true");
 
                 saveDocument(file, doc);
 

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/DebuggableFalseChangeToTrueTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/DebuggableFalseChangeToTrueTest.java
@@ -1,0 +1,93 @@
+/**
+ *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
+ *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package brut.androlib.aapt2;
+
+import brut.androlib.*;
+import brut.common.BrutException;
+import brut.directory.ExtFile;
+import brut.util.OS;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Connor Tumbleson <connor.tumbleson@gmail.com>
+ */
+public class DebuggableFalseChangeToTrueTest extends BaseTest {
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        TestUtils.cleanFrameworkFile();
+        sTmpDir = new ExtFile(OS.createTempDirectory());
+        sTestOrigDir = new ExtFile(sTmpDir, "issue2328-debuggable-false-orig");
+        sTestNewDir = new ExtFile(sTmpDir, "issue2328-debuggable-flase-new");
+        LOGGER.info("Unpacking issue2328-debuggable-flase...");
+        TestUtils.copyResourceDir(DebuggableFalseChangeToTrueTest.class, "aapt2/issue2328/debuggable-false", sTestOrigDir);
+
+        LOGGER.info("Building issue2328-debuggable-flase.apk...");
+        ApkOptions apkOptions = new ApkOptions();
+        apkOptions.debugMode = true;
+        apkOptions.useAapt2 = true;
+        apkOptions.verbose = true;
+
+        File testApk = new File(sTmpDir, "issue2328-debuggable-flase.apk");
+        new Androlib(apkOptions).build(sTestOrigDir, testApk);
+
+        LOGGER.info("Decoding issue2328-debuggable-flase.apk...");
+        ApkDecoder apkDecoder = new ApkDecoder(testApk);
+        apkDecoder.setOutDir(sTestNewDir);
+        apkDecoder.decode();
+    }
+
+    @AfterClass
+    public static void afterClass() throws BrutException {
+        OS.rmdir(sTmpDir);
+    }
+
+    @Test
+    public void buildAndDecodeTest() {
+        assertTrue(sTestNewDir.isDirectory());
+    }
+
+    @Test
+    public void DebugIsTruePriorToBeingFalseTest() throws IOException, SAXException {
+        String apk = "issue2328-debuggable-flase-new";
+
+        String expected = TestUtils.replaceNewlines("<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>" +
+                "<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\" android:compileSdkVersion=\"23\" " +
+                "android:compileSdkVersionCodename=\"6.0-2438415\" package=\"com.ibotpeaches.issue2328\" platformBuildVersionCode=\"23\" " +
+                "platformBuildVersionName=\"6.0-2438415\">    <application android:debuggable=\"true\"/></manifest>");
+
+        byte[] encoded = Files.readAllBytes(Paths.get(sTmpDir + File.separator + apk + File.separator + "AndroidManifest.xml"));
+        String obtained = TestUtils.replaceNewlines(new String(encoded));
+
+        XMLUnit.setIgnoreWhitespace(true);
+        XMLUnit.setIgnoreAttributeOrder(true);
+        XMLUnit.setCompareUnmatched(false);
+
+        assertXMLEqual(expected, obtained);
+    }
+}

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/DebuggableTrueAddedTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/DebuggableTrueAddedTest.java
@@ -1,0 +1,93 @@
+/**
+ *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
+ *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package brut.androlib.aapt2;
+
+import brut.androlib.*;
+import brut.common.BrutException;
+import brut.directory.ExtFile;
+import brut.util.OS;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Connor Tumbleson <connor.tumbleson@gmail.com>
+ */
+public class DebuggableTrueAddedTest extends BaseTest {
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        TestUtils.cleanFrameworkFile();
+        sTmpDir = new ExtFile(OS.createTempDirectory());
+        sTestOrigDir = new ExtFile(sTmpDir, "issue2328-debuggable-missing-orig");
+        sTestNewDir = new ExtFile(sTmpDir, "issue2328-debuggable-missing-new");
+        LOGGER.info("Unpacking issue2328-debuggable-missing...");
+        TestUtils.copyResourceDir(DebuggableTrueAddedTest.class, "aapt2/issue2328/debuggable-missing", sTestOrigDir);
+
+        LOGGER.info("Building issue2328-debuggable-missing.apk...");
+        ApkOptions apkOptions = new ApkOptions();
+        apkOptions.debugMode = true;
+        apkOptions.useAapt2 = true;
+        apkOptions.verbose = true;
+
+        File testApk = new File(sTmpDir, "issue2328-debuggable-missing.apk");
+        new Androlib(apkOptions).build(sTestOrigDir, testApk);
+
+        LOGGER.info("Decoding issue2328-debuggable-missing.apk...");
+        ApkDecoder apkDecoder = new ApkDecoder(testApk);
+        apkDecoder.setOutDir(sTestNewDir);
+        apkDecoder.decode();
+    }
+
+    @AfterClass
+    public static void afterClass() throws BrutException {
+        OS.rmdir(sTmpDir);
+    }
+
+    @Test
+    public void buildAndDecodeTest() {
+        assertTrue(sTestNewDir.isDirectory());
+    }
+
+    @Test
+    public void DebugIsTruePriorToBeingFalseTest() throws IOException, SAXException {
+        String apk = "issue2328-debuggable-missing-new";
+
+        String expected = TestUtils.replaceNewlines("<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>" +
+                "<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\" android:compileSdkVersion=\"23\" " +
+                "android:compileSdkVersionCodename=\"6.0-2438415\" package=\"com.ibotpeaches.issue2328\" platformBuildVersionCode=\"23\" " +
+                "platformBuildVersionName=\"6.0-2438415\">    <application android:debuggable=\"true\"/></manifest>");
+
+        byte[] encoded = Files.readAllBytes(Paths.get(sTmpDir + File.separator + apk + File.separator + "AndroidManifest.xml"));
+        String obtained = TestUtils.replaceNewlines(new String(encoded));
+
+        XMLUnit.setIgnoreWhitespace(true);
+        XMLUnit.setIgnoreAttributeOrder(true);
+        XMLUnit.setCompareUnmatched(false);
+
+        assertXMLEqual(expected, obtained);
+    }
+}

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/DebuggableTrueRetainedTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/DebuggableTrueRetainedTest.java
@@ -1,0 +1,93 @@
+/**
+ *  Copyright (C) 2019 Ryszard Wiśniewski <brut.alll@gmail.com>
+ *  Copyright (C) 2019 Connor Tumbleson <connor.tumbleson@gmail.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package brut.androlib.aapt2;
+
+import brut.androlib.*;
+import brut.common.BrutException;
+import brut.directory.ExtFile;
+import brut.util.OS;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Connor Tumbleson <connor.tumbleson@gmail.com>
+ */
+public class DebuggableTrueRetainedTest extends BaseTest {
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        TestUtils.cleanFrameworkFile();
+        sTmpDir = new ExtFile(OS.createTempDirectory());
+        sTestOrigDir = new ExtFile(sTmpDir, "issue2328-debuggable-true-orig");
+        sTestNewDir = new ExtFile(sTmpDir, "issue2328-debuggable-true-new");
+        LOGGER.info("Unpacking issue2328-debuggable-true...");
+        TestUtils.copyResourceDir(DebuggableTrueRetainedTest.class, "aapt2/issue2328/debuggable-true", sTestOrigDir);
+
+        LOGGER.info("Building issue2328-debuggable-true.apk...");
+        ApkOptions apkOptions = new ApkOptions();
+        apkOptions.debugMode = true;
+        apkOptions.useAapt2 = true;
+        apkOptions.verbose = true;
+
+        File testApk = new File(sTmpDir, "issue2328-debuggable-true.apk");
+        new Androlib(apkOptions).build(sTestOrigDir, testApk);
+
+        LOGGER.info("Decoding issue2328-debuggable-true.apk...");
+        ApkDecoder apkDecoder = new ApkDecoder(testApk);
+        apkDecoder.setOutDir(sTestNewDir);
+        apkDecoder.decode();
+    }
+
+    @AfterClass
+    public static void afterClass() throws BrutException {
+        OS.rmdir(sTmpDir);
+    }
+
+    @Test
+    public void buildAndDecodeTest() {
+        assertTrue(sTestNewDir.isDirectory());
+    }
+
+    @Test
+    public void DebugIsTruePriorToBeingFalseTest() throws IOException, SAXException {
+        String apk = "issue2328-debuggable-true-new";
+
+        String expected = TestUtils.replaceNewlines("<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>" +
+                "<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\" android:compileSdkVersion=\"23\" " +
+                "android:compileSdkVersionCodename=\"6.0-2438415\" package=\"com.ibotpeaches.issue2328\" platformBuildVersionCode=\"23\" " +
+                "platformBuildVersionName=\"6.0-2438415\">    <application android:debuggable=\"true\"/></manifest>");
+
+        byte[] encoded = Files.readAllBytes(Paths.get(sTmpDir + File.separator + apk + File.separator + "AndroidManifest.xml"));
+        String obtained = TestUtils.replaceNewlines(new String(encoded));
+
+        XMLUnit.setIgnoreWhitespace(true);
+        XMLUnit.setIgnoreAttributeOrder(true);
+        XMLUnit.setCompareUnmatched(false);
+
+        assertXMLEqual(expected, obtained);
+    }
+}

--- a/brut.apktool/apktool-lib/src/test/resources/aapt2/issue2328/debuggable-false/AndroidManifest.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/aapt2/issue2328/debuggable-false/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.ibotpeaches.issue2328" xmlns:android="http://schemas.android.com/apk/res/android" platformBuildVersionCode="20" platformBuildVersionName="4.4W.2-1537038">
+<application android:debuggable="false"/>
+</manifest>

--- a/brut.apktool/apktool-lib/src/test/resources/aapt2/issue2328/debuggable-false/apktool.yml
+++ b/brut.apktool/apktool-lib/src/test/resources/aapt2/issue2328/debuggable-false/apktool.yml
@@ -1,0 +1,12 @@
+version: 2.0.0
+apkFileName: issue1235.apk
+isFrameworkApk: false
+usesFramework:
+  ids:
+  - 1
+packageInfo:
+  forcedPackageId: '127'
+versionInfo:
+  versionCode: '1'
+  versionName: '1.0'
+compressionType: false

--- a/brut.apktool/apktool-lib/src/test/resources/aapt2/issue2328/debuggable-false/apktool.yml
+++ b/brut.apktool/apktool-lib/src/test/resources/aapt2/issue2328/debuggable-false/apktool.yml
@@ -1,5 +1,5 @@
 version: 2.0.0
-apkFileName: issue1235.apk
+apkFileName: issue2328.apk
 isFrameworkApk: false
 usesFramework:
   ids:

--- a/brut.apktool/apktool-lib/src/test/resources/aapt2/issue2328/debuggable-false/res/values/strings.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/aapt2/issue2328/debuggable-false/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="hello_world">Hello World</string>
+</resources>

--- a/brut.apktool/apktool-lib/src/test/resources/aapt2/issue2328/debuggable-missing/AndroidManifest.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/aapt2/issue2328/debuggable-missing/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.ibotpeaches.issue2328" xmlns:android="http://schemas.android.com/apk/res/android" platformBuildVersionCode="20" platformBuildVersionName="4.4W.2-1537038">
+<application/>
+</manifest>

--- a/brut.apktool/apktool-lib/src/test/resources/aapt2/issue2328/debuggable-missing/apktool.yml
+++ b/brut.apktool/apktool-lib/src/test/resources/aapt2/issue2328/debuggable-missing/apktool.yml
@@ -1,0 +1,12 @@
+version: 2.0.0
+apkFileName: issue1235.apk
+isFrameworkApk: false
+usesFramework:
+  ids:
+  - 1
+packageInfo:
+  forcedPackageId: '127'
+versionInfo:
+  versionCode: '1'
+  versionName: '1.0'
+compressionType: false

--- a/brut.apktool/apktool-lib/src/test/resources/aapt2/issue2328/debuggable-missing/apktool.yml
+++ b/brut.apktool/apktool-lib/src/test/resources/aapt2/issue2328/debuggable-missing/apktool.yml
@@ -1,5 +1,5 @@
 version: 2.0.0
-apkFileName: issue1235.apk
+apkFileName: issue2328.apk
 isFrameworkApk: false
 usesFramework:
   ids:

--- a/brut.apktool/apktool-lib/src/test/resources/aapt2/issue2328/debuggable-missing/res/values/strings.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/aapt2/issue2328/debuggable-missing/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="hello_world">Hello World</string>
+</resources>

--- a/brut.apktool/apktool-lib/src/test/resources/aapt2/issue2328/debuggable-true/AndroidManifest.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/aapt2/issue2328/debuggable-true/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.ibotpeaches.issue2328" xmlns:android="http://schemas.android.com/apk/res/android" platformBuildVersionCode="20" platformBuildVersionName="4.4W.2-1537038">
+<application android:debuggable="true"/>
+</manifest>

--- a/brut.apktool/apktool-lib/src/test/resources/aapt2/issue2328/debuggable-true/apktool.yml
+++ b/brut.apktool/apktool-lib/src/test/resources/aapt2/issue2328/debuggable-true/apktool.yml
@@ -1,0 +1,12 @@
+version: 2.0.0
+apkFileName: issue1235.apk
+isFrameworkApk: false
+usesFramework:
+  ids:
+  - 1
+packageInfo:
+  forcedPackageId: '127'
+versionInfo:
+  versionCode: '1'
+  versionName: '1.0'
+compressionType: false

--- a/brut.apktool/apktool-lib/src/test/resources/aapt2/issue2328/debuggable-true/apktool.yml
+++ b/brut.apktool/apktool-lib/src/test/resources/aapt2/issue2328/debuggable-true/apktool.yml
@@ -1,5 +1,5 @@
 version: 2.0.0
-apkFileName: issue1235.apk
+apkFileName: issue2328.apk
 isFrameworkApk: false
 usesFramework:
   ids:

--- a/brut.apktool/apktool-lib/src/test/resources/aapt2/issue2328/debuggable-true/res/values/strings.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/aapt2/issue2328/debuggable-true/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="hello_world">Hello World</string>
+</resources>


### PR DESCRIPTION
Closes #2328 

- when using aapt and debug flag, we remove the 'debuggable' attribute from AndroidManifest and aapt adds it back. (see issue 1621)
- when using aapt2 and debug flag, we add and set the value of 'debuggable' attribute ourselves.