### PR TITLE
exit code 1 if parameters are wrong

### DIFF
--- a/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
+++ b/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
@@ -54,6 +54,7 @@ public class Main {
         } catch (ParseException ex) {
             System.err.println(ex.getMessage());
             usage();
+            System.exit(1);
             return;
         }
 


### PR DESCRIPTION
for use in scripts, it's not convenient to get an exit code 0 on
failure.