### PR TITLE
Test improvement

### DIFF
--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/DoubleExtensionUnknownFileTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/DoubleExtensionUnknownFileTest.java
@@ -26,6 +26,7 @@ import brut.common.BrutException;
 import brut.util.OS;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.AfterClass;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -56,9 +57,12 @@ public class DoubleExtensionUnknownFileTest extends BaseTest {
         String apk = "issue1244.apk";
 
         // decode issue1244.apk
-        ApkDecoder apkDecoder = new ApkDecoder(new File(sTmpDir + File.separator + apk));
+        File apkDecoderFile = new File(sTmpDir + File.separator + apk);
+        Assume.assumeTrue(apkDecoderFile.exists());
+        ApkDecoder apkDecoder = new ApkDecoder(apkDecoderFile);
         ExtFile decodedApk = new ExtFile(sTmpDir + File.separator + apk + ".out");
-        apkDecoder.setOutDir(new File(sTmpDir + File.separator + apk + ".out"));
+        File outDir = new File(sTmpDir + File.separator + apk + ".out");
+        apkDecoder.setOutDir(outDir);
         apkDecoder.decode();
 
         MetaInfo metaInfo = new Androlib().readMetaFile(decodedApk);

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/DoubleExtensionUnknownFileTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/DoubleExtensionUnknownFileTest.java
@@ -61,8 +61,7 @@ public class DoubleExtensionUnknownFileTest extends BaseTest {
         Assume.assumeTrue(apkDecoderFile.exists());
         ApkDecoder apkDecoder = new ApkDecoder(apkDecoderFile);
         ExtFile decodedApk = new ExtFile(sTmpDir + File.separator + apk + ".out");
-        File outDir = new File(sTmpDir + File.separator + apk + ".out");
-        apkDecoder.setOutDir(outDir);
+        apkDecoder.setOutDir(new File(sTmpDir + File.separator + apk + ".out"));
         apkDecoder.decode();
 
         MetaInfo metaInfo = new Androlib().readMetaFile(decodedApk);


### PR DESCRIPTION
This is a test refactoring.

The resource optimism occurs when a test method makes an optimistic assumption that the external resource (e.g., File), utilized by the test method, exists.

As this test creates a file, it is necessary to ensure that any problems caused by the existance (or not) of this file will not affect the result of the test method even without testing what is meant to be tested. In order to do that, we use JUnit's 5 API Assume to make sure that the test file will exist, and if it doesn't just skip the test, since the test goal will not be reached. 