### PR TITLE
Properly handle non-framework namespaces when obfuscated

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AXmlResourceParser.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AXmlResourceParser.java
@@ -296,7 +296,7 @@ public class AXmlResourceParser implements XmlResourceParser {
         if (value.length() == 0) {
             ResID resourceId = new ResID(getAttributeNameResource(index));
             if (resourceId.package_ == PRIVATE_PKG_ID) {
-                value = getNonDefaultNamespaceUri();
+                value = getNonDefaultNamespaceUri(offset);
             } else {
                 value = android_ns;
             }
@@ -305,15 +305,19 @@ public class AXmlResourceParser implements XmlResourceParser {
         return value;
     }
 
-    private String getNonDefaultNamespaceUri() {
-        int offset = m_namespaces.getCurrentCount() + 1;
-        String prefix = m_strings.getString(m_namespaces.get(offset, true));
-
-        if (! prefix.equalsIgnoreCase("android")) {
-            return  m_strings.getString(m_namespaces.get(offset, false));
+    private String getNonDefaultNamespaceUri(int offset) {
+        String prefix = m_strings.getString(m_namespaces.getPrefix(offset));
+        if (prefix != null) {
+            return  m_strings.getString(m_namespaces.getUri(offset));
         }
 
-        return android_ns;
+        // If we are here. There is some clever obfuscation going on. Our reference points to the namespace are gone.
+        // Normally we could take the index * attributeCount to get an offset.
+        // That would point to the URI in the StringBlock table, but that is empty.
+        // We have the namespaces that can't be touched in the opening tag.
+        // Though no known way to correlate them at this time.
+        // So return the res-auto namespace.
+        return "http://schemas.android.com/apk/res-auto";
     }
 
     @Override
@@ -985,7 +989,7 @@ public class AXmlResourceParser implements XmlResourceParser {
     private StringBlock m_strings;
     private int[] m_resourceIDs;
     private NamespaceStack m_namespaces = new NamespaceStack();
-    private String android_ns = "http://schemas.android.com/apk/res/android";
+    private final String android_ns = "http://schemas.android.com/apk/res/android";
     private boolean m_decreaseDepth;
     private int m_event;
     private int m_lineNumber;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
@@ -94,15 +94,15 @@ public class StringBlock {
         int offset = m_stringOffsets[index];
         int length;
 
+        int[] val;
         if (m_isUTF8) {
-            int[] val = getUtf8(m_strings, offset);
+            val = getUtf8(m_strings, offset);
             offset = val[0];
-            length = val[1];
         } else {
-            int[] val = getUtf16(m_strings, offset);
+            val = getUtf16(m_strings, offset);
             offset += val[0];
-            length = val[1];
         }
+        length = val[1];
         return decodeString(offset, length);
     }
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
@@ -264,20 +264,21 @@ public class StringBlock {
             return null;
         }
         int offset = m_styleOffsets[index] / 4;
-        int style[];
-        {
-            int count = 0;
-            for (int i = offset; i < m_styles.length; ++i) {
-                if (m_styles[i] == -1) {
-                    break;
-                }
-                count += 1;
+        int count = 0;
+        int[] style;
+
+        for (int i = offset; i < m_styles.length; ++i) {
+            if (m_styles[i] == -1) {
+                break;
             }
-            if (count == 0 || (count % 3) != 0) {
-                return null;
-            }
-            style = new int[count];
+            count += 1;
         }
+
+        if (count == 0 || (count % 3) != 0) {
+            return null;
+        }
+        style = new int[count];
+
         for (int i = offset, j = 0; i < m_styles.length;) {
             if (m_styles[i] == -1) {
                 break;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
@@ -21,8 +21,6 @@ import brut.util.ExtDataInput;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.*;
-import java.util.Arrays;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
@@ -121,7 +121,7 @@ public class StringBlock {
     public String getHTML(int index) {
         String raw = getString(index);
         if (raw == null) {
-            return raw;
+            return null;
         }
         int[] style = getStyle(index);
         if (style == null) {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
@@ -54,8 +54,6 @@ public class StringBlock {
         StringBlock block = new StringBlock();
         block.m_isUTF8 = (flags & UTF8_FLAG) != 0;
         block.m_stringOffsets = reader.readIntArray(stringCount);
-        block.m_stringOwns = new int[stringCount];
-        Arrays.fill(block.m_stringOwns, -1);
 
         if (styleCount != 0) {
             block.m_styleOffsets = reader.readIntArray(styleCount);
@@ -353,7 +351,6 @@ public class StringBlock {
     private int[] m_styleOffsets;
     private int[] m_styles;
     private boolean m_isUTF8;
-    private int[] m_stringOwns;
 
     private final CharsetDecoder UTF16LE_DECODER = Charset.forName("UTF-16LE").newDecoder();
     private final CharsetDecoder UTF8_DECODER = Charset.forName("UTF-8").newDecoder();


### PR DESCRIPTION
fixes #2317 