### PR TITLE
Use CESU-8 decoder if UTF-8 decoder fails (issue #2299)

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
@@ -18,6 +18,8 @@ package brut.androlib.res.decoder;
 
 import brut.androlib.res.xml.ResXmlEncoders;
 import brut.util.ExtDataInput;
+import com.google.common.annotations.VisibleForTesting;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.*;
@@ -254,6 +256,12 @@ public class StringBlock {
     private StringBlock() {
     }
 
+    @VisibleForTesting
+    StringBlock(byte[] strings, boolean isUTF8) {
+        m_strings = strings;
+        m_isUTF8 = isUTF8;
+    }
+
     /**
      * Returns style information - array of int triplets, where in each triplet:
      * * first int is index of tag name ('b','i', etc.) * second int is tag
@@ -288,7 +296,8 @@ public class StringBlock {
         return style;
     }
 
-    private String decodeString(int offset, int length) {
+    @VisibleForTesting
+    String decodeString(int offset, int length) {
         try {
             return (m_isUTF8 ? UTF8_DECODER : UTF16LE_DECODER).decode(
                     ByteBuffer.wrap(m_strings, offset, length)).toString();

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/res/decoder/StringBlockWithSurrogatePairInUtf8Test.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/res/decoder/StringBlockWithSurrogatePairInUtf8Test.java
@@ -1,0 +1,49 @@
+package brut.androlib.res.decoder;
+
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+
+public class StringBlockWithSurrogatePairInUtf8Test {
+    @Test
+    public void decodeSingleOctet() {
+        final String actual = new StringBlock("abcDEF123".getBytes(StandardCharsets.UTF_8), true).decodeString(0, 9);
+        assertEquals("Incorrect decoding", "abcDEF123", actual);
+    }
+
+    @Test
+    public void decodeTwoOctets() {
+        final String actual0 = new StringBlock(new byte[] {	(byte) 0xC2, (byte) 0x80}, true).decodeString(0, 2);
+        assertEquals("Incorrect decoding", "\u0080", actual0);
+
+        final String actual1 = new StringBlock(new byte[] {	(byte) 0xDF, (byte) 0xBF}, true).decodeString(0, 2);
+        assertEquals("Incorrect decoding", "\u07FF", actual1);
+    }
+
+    @Test
+    public void decodeThreeOctets() {
+        final String actual0 = new StringBlock(new byte[] {	(byte) 0xE0, (byte) 0xA0, (byte) 0x80}, true).decodeString(0, 3);
+        assertEquals("Incorrect decoding", "\u0800", actual0);
+
+        final String actual1 = new StringBlock(new byte[] {	(byte) 0xEF, (byte) 0xBF, (byte) 0xBF}, true).decodeString(0, 3);
+        assertEquals("Incorrect decoding", "\uFFFF", actual1);
+    }
+
+    @Test
+    public void decodeSurrogatePair_when_givesAsThreeOctetsFromInvalidRangeOfUtf8() {
+        // See: https://github.com/iBotPeaches/Apktool/issues/2299
+        final String actual0 = new StringBlock(new byte[] {	(byte) 0xED, (byte) 0xA0, (byte) 0xBD, (byte) 0xED, (byte) 0xB4, (byte) 0x86}, true).decodeString(0, 6);
+        assertEquals("Incorrect decoding", "\uD83D\uDD06", actual0);
+    }
+
+    @Test
+    public void decodeSurrogatePair_when_givesAsThreeOctetsFromTheValidRangeOfUtf8() {
+        // \u10FFFF is encoded in UTF-8 as "0xDBFF 0xDFFF" (4-byte encoding),
+        // but when used in Android resources which are encoded in UTF-8, 3-byte encoding is used,
+        // so each of these is encoded as 3-bytes
+        final String actual0 = new StringBlock(new byte[] {	(byte) 0xED, (byte) 0xAF, (byte) 0xBF, (byte) 0xED, (byte) 0xBF, (byte) 0xBF}, true).decodeString(0, 6);
+        assertEquals("Incorrect decoding", "\uDBFF\uDFFF", actual0);
+    }
+}

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/res/decoder/StringBlockWithSurrogatePairInUtf8Test.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/res/decoder/StringBlockWithSurrogatePairInUtf8Test.java
@@ -34,8 +34,8 @@ public class StringBlockWithSurrogatePairInUtf8Test {
     @Test
     public void decodeSurrogatePair_when_givesAsThreeOctetsFromInvalidRangeOfUtf8() {
         // See: https://github.com/iBotPeaches/Apktool/issues/2299
-        final String actual0 = new StringBlock(new byte[] {	(byte) 0xED, (byte) 0xA0, (byte) 0xBD, (byte) 0xED, (byte) 0xB4, (byte) 0x86}, true).decodeString(0, 6);
-        assertEquals("Incorrect decoding", "\uD83D\uDD06", actual0);
+        final String actual = new StringBlock(new byte[] {	(byte) 0xED, (byte) 0xA0, (byte) 0xBD, (byte) 0xED, (byte) 0xB4, (byte) 0x86}, true).decodeString(0, 6);
+        assertEquals("Incorrect decoding", "\uD83D\uDD06", actual);
     }
 
     @Test
@@ -43,7 +43,7 @@ public class StringBlockWithSurrogatePairInUtf8Test {
         // \u10FFFF is encoded in UTF-8 as "0xDBFF 0xDFFF" (4-byte encoding),
         // but when used in Android resources which are encoded in UTF-8, 3-byte encoding is used,
         // so each of these is encoded as 3-bytes
-        final String actual0 = new StringBlock(new byte[] {	(byte) 0xED, (byte) 0xAF, (byte) 0xBF, (byte) 0xED, (byte) 0xBF, (byte) 0xBF}, true).decodeString(0, 6);
-        assertEquals("Incorrect decoding", "\uDBFF\uDFFF", actual0);
+        final String actual = new StringBlock(new byte[] {	(byte) 0xED, (byte) 0xAF, (byte) 0xBF, (byte) 0xED, (byte) 0xBF, (byte) 0xBF}, true).decodeString(0, 6);
+        assertEquals("Incorrect decoding", "\uDBFF\uDFFF", actual);
     }
 }


### PR DESCRIPTION
Closes #2299 

- [DEX format uses Modified UTF-8](https://source.android.com/devices/tech/dalvik/dex-format#mutf-8) which includes:
_Code points in the range U+10000 … U+10ffff are encoded as a surrogate pair, each of which is represented as a three-byte encoded value._
...
_MUTF-8 is actually closer to the (relatively less well-known) encoding CESU-8 than to UTF-8 per se._

Based in this, I suggest this change:
- If decoding fails for a UTF-8 "String block", then try to use CESU-8.
- I didn't want to always use CESU-8 because it's not clear that it is the actual decoder that should be used, but it does seem to work for the specific examples I tried.
- I wrote some unit tests for StringBlock#decodeString. I didn't add tests at a higher level, i.e., decoding an APK and verifying the resources' values as in DecodeArrayTest.