### PR TITLE
support lib/specType out-of-order reading - fix "Invalid chunk type: expected=0x00000200, got=0x00000203"

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
@@ -123,12 +123,19 @@ public class ARSCDecoder {
         mPkg = new ResPackage(mResTable, id, name);
 
         nextChunk();
-        while (mHeader.type == Header.TYPE_LIBRARY) {
-            readLibraryType();
-        }
-
-        while (mHeader.type == Header.TYPE_SPEC_TYPE) {
-            readTableTypeSpec();
+        boolean flag = true;
+        while (flag) {
+            switch (mHeader.type) {
+                case Header.TYPE_LIBRARY:
+                    readLibraryType();
+                    break;
+                case Header.TYPE_SPEC_TYPE:
+                    readTableTypeSpec();
+                    break;
+                default:
+                    flag = false;
+                    break;
+            }
         }
 
         return mPkg;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
@@ -302,8 +302,8 @@ public class StringBlock {
         try {
             return (m_isUTF8 ? UTF8_DECODER : UTF16LE_DECODER).decode(wrappedBuffer).toString();
         } catch (CharacterCodingException ex) {
-            LOGGER.warning("Failed to decode a string at offset " + offset + " of length " + length);
             if (!m_isUTF8) {
+                LOGGER.warning("Failed to decode a string at offset " + offset + " of length " + length);
                 return null;
             }
         }


### PR DESCRIPTION
When decoding an apk assembled with an app bundle, like TikTok, Apktool will raise a error:
![image](https://user-images.githubusercontent.com/13981123/110200958-a2b91000-7e9b-11eb-9a72-7dd515ba76b4.png)
Look at [ARSCDecoder.java#L126](https://github.com/iBotPeaches/Apktool/blob/master/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java#L126) we can find the reason: 
``` Java
  while (mHeader.type == Header.TYPE_LIBRARY) {
      readLibraryType();
  }

  while (mHeader.type == Header.TYPE_SPEC_TYPE) {
      readTableTypeSpec();
  }
```
Apktool expected to read lib chunks first and then specType chunks. But in AOSP [LoadedArsc.cpp#L420](http://androidxref.com/9.0.0_r3/xref/frameworks/base/libs/androidfw/LoadedArsc.cpp#420) we can find that Google does not specify the order of the two. 
So when decoding these apks, `ResPackage readTablePackage()` just read spec types and return, left the rest library chunks alone. Then [ARSCDecoder.java#L82](https://github.com/iBotPeaches/Apktool/blob/master/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java#L82) called `ResPackage readTablePackage()`  again, `checkChunkType(Header.TYPE_PACKAGE)` fail because that there are some library chunks. 

This PR add lib/specType chunks out-of-order reading support. So now we can decode these apks normally:
![image](https://user-images.githubusercontent.com/13981123/110201514-7652c300-7e9e-11eb-8f66-ed288e05fbf1.png)
