### PR TITLE
Create a new ByteBuffer for decoding when retrying with CESU-8

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
@@ -284,8 +284,8 @@ public class StringBlock {
 
     @VisibleForTesting
     String decodeString(int offset, int length) {
-        final ByteBuffer wrappedBuffer = ByteBuffer.wrap(m_strings, offset, length);
         try {
+            final ByteBuffer wrappedBuffer = ByteBuffer.wrap(m_strings, offset, length);
             return (m_isUTF8 ? UTF8_DECODER : UTF16LE_DECODER).decode(wrappedBuffer).toString();
         } catch (CharacterCodingException ex) {
             if (!m_isUTF8) {
@@ -295,9 +295,10 @@ public class StringBlock {
         }
 
         try {
+            final ByteBuffer wrappedBufferRetry = ByteBuffer.wrap(m_strings, offset, length);
             // in some places, Android uses 3-byte UTF-8 sequences instead of 4-bytes.
             // If decoding failed, we try to use CESU-8 decoder, which is closer to what Android actually uses.
-            return CESU8_DECODER.decode(wrappedBuffer).toString();
+            return CESU8_DECODER.decode(wrappedBufferRetry).toString();
         } catch (CharacterCodingException e) {
             LOGGER.warning("Failed to decode a string with CESU-8 decoder.");
             return null;

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/res/decoder/StringBlockWithSurrogatePairInUtf8Test.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/res/decoder/StringBlockWithSurrogatePairInUtf8Test.java
@@ -52,6 +52,20 @@ public class StringBlockWithSurrogatePairInUtf8Test {
         // See: https://github.com/iBotPeaches/Apktool/issues/2299
         final String actual = new StringBlock(new byte[] {	(byte) 0xED, (byte) 0xA0, (byte) 0xBD, (byte) 0xED, (byte) 0xB4, (byte) 0x86}, true).decodeString(0, 6);
         assertEquals("Incorrect decoding", "\uD83D\uDD06", actual);
+
+        // See: https://github.com/iBotPeaches/Apktool/issues/2546
+        final byte[] bytesWithCharactersBeforeSurrogatePair = {'G', 'o', 'o', 'd', ' ', 'm', 'o', 'r', 'n', 'i', 'n', 'g', '!', ' ',
+                (byte) 0xED, (byte) 0xA0, (byte) 0xBD, (byte) 0xED, (byte) 0xB1, (byte) 0x8B,
+                ' ', 'S', 'u', 'n', ' ',
+                (byte) 0xED, (byte) 0xA0, (byte) 0xBD, (byte) 0xED, (byte) 0xBC, (byte) 0x9E
+        };
+        final String actual2 = new StringBlock(bytesWithCharactersBeforeSurrogatePair, true).decodeString(0, 31);
+
+        // D83D -> ED 0xA0 0xBD
+        // DC4B -> 0xED 0xB1 0x8B
+        // DF1E -> 0xED 0xBC 0x9E
+        assertEquals("Incorrect decoding when there are valid characters before the surrogate pair",
+                "Good morning! \uD83D\uDC4B Sun \uD83C\uDF1E", actual2);
     }
 
     @Test

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/res/decoder/StringBlockWithSurrogatePairInUtf8Test.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/res/decoder/StringBlockWithSurrogatePairInUtf8Test.java
@@ -57,12 +57,13 @@ public class StringBlockWithSurrogatePairInUtf8Test {
         final byte[] bytesWithCharactersBeforeSurrogatePair = {'G', 'o', 'o', 'd', ' ', 'm', 'o', 'r', 'n', 'i', 'n', 'g', '!', ' ',
                 (byte) 0xED, (byte) 0xA0, (byte) 0xBD, (byte) 0xED, (byte) 0xB1, (byte) 0x8B,
                 ' ', 'S', 'u', 'n', ' ',
-                (byte) 0xED, (byte) 0xA0, (byte) 0xBD, (byte) 0xED, (byte) 0xBC, (byte) 0x9E
+                (byte) 0xED, (byte) 0xA0, (byte) 0xBC, (byte) 0xED, (byte) 0xBC, (byte) 0x9E
         };
         final String actual2 = new StringBlock(bytesWithCharactersBeforeSurrogatePair, true).decodeString(0, 31);
 
-        // D83D -> ED 0xA0 0xBD
+        // D83D -> 0xED 0xA0 0xBD
         // DC4B -> 0xED 0xB1 0x8B
+        // D83C -> 0xED 0xA0 0xBC
         // DF1E -> 0xED 0xBC 0x9E
         assertEquals("Incorrect decoding when there are valid characters before the surrogate pair",
                 "Good morning! \uD83D\uDC4B Sun \uD83C\uDF1E", actual2);


### PR DESCRIPTION
Fixes #2546

This fixes a case which wasn't handled in #2299.

* When a string can't be decoded with UTF-8, we retry the decoding with CESU-8 (done as part of #2299)
* If the bytes that can't be decoded are not at the start of the bytes range to be decoded, then the UTF-8 decoder changes the position of the ByteBuffer and the CESU-8 decoder will start decoding at the new position.
* To avoid this, we wrap the  array with a new ByteBuffer and use it with the CESU-8 decoder.

For example, before this change, when trying to decode with UTF-8 the bytes representing the following:
Good morning! 👋 Sun 🌞
The UTF-8 will read from the byte buffer partially and the CESU-8 will decode this:
👋 Sun 🌞