### PR TITLE
update apktool.bat

### DIFF
--- a/scripts/windows/apktool.bat
+++ b/scripts/windows/apktool.bat
@@ -7,6 +7,17 @@ set java_exe=java.exe
 
 if defined JAVA_HOME (
 set java_exe="%JAVA_HOME%\bin\java.exe"
+) else ( rem in case not defined JAVA_HOME
+rem to work with jre 1.8 installed by IntelliJ IDEA in default folders uncomment the next line (with specific one )
+rem set java_exe= "%UserProfile%\.jdks\corretto-1.8.0_292\jre\bin\java.exe"
+rem to work with any jre installed by IntelliJ IDEA in default folders uncomment the next line
+rem for /d %%D in ("%UserProfile%\.jdks\*") do set java_exe= "%%~fD\jre\bin\java.exe"
+
+rem to work with jdk 16 uncomment the next line (with specific one )
+rem set java_exe= "C:\Program Files\Java\jdk-16.0.1\bin\java.exe"
+rem to work with any jdk present uncomment the next line
+rem set java_exe= "C:\Program Files\Java\j*\bin\java.exe" -dont work
+for /d %%D in ("C:\Program Files\Java\jdk*") do set java_exe= "%%~fD\bin\java.exe"
 )
 
 rem Find the highest version .jar available in the same directory as the script


### PR DESCRIPTION
- to work even without java_home defined . i tested many times and all those options work.
i left uncommented the line to work with any jdk present.

i dont know why but in my pc im adding java_home to path but it does not get recognized. already restarted IDE's and cmd but no fix. i've also not restarted windows yet  because thats too much still open here. maybe thats the problem.
but anyway this makes it more resilient to work in enviroments that had java just installed, and because of that it may probably be more resilient to work in vm's, dockers and alike.