### PR TITLE
Directly point to #apktool channel

### DIFF
--- a/index.md
+++ b/index.md
@@ -32,7 +32,7 @@ It is **NOT** intended for piracy and other non-legal uses. It could be used for
  * [XDA Thread](https://forum.xda-developers.com/showthread.php?t=1755243) - For those who wish to communicate on XDA-Developers for community support
  * [Smali Project](https://github.com/JesusFreke/smali) - Smali Project is the tool used in the disassembling of `.dex` files
  * [Gitter #apktool](https://gitter.im/iBotPeaches/Apktool) - Gitter Channel for support, bugs and discussions
- * [Libera.chat #apktool](https://web.libera.chat/) - IRC Channel for support, bugs and discussions
+ * [Libera.chat #apktool](https://web.libera.chat/#apktool) - IRC Channel for support, bugs and discussions
 
 ## Authors
 <ul>


### PR DESCRIPTION
When clicking on the IRC link, the channel textbox is now properly filled with the channel name, instead of the default #libera name