### PR TITLE
fix wrong HTML start/end tags in strings.xml

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
@@ -232,10 +232,7 @@ public class StringBlock {
         }
         string.append(ResXmlEncoders.escapeXmlChars(raw.substring(lastIndex)));
 
-        String res = string.toString();
-
-        LOGGER.severe(res);
-        return res;
+        return string.toString();
     }
 
     /**

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
@@ -124,7 +124,17 @@ public class StringBlock {
             this.position = position;
             this.matchingTagPosition = matchingTagPosition;
         }
-
+        
+        /**
+         * compares this tag and another, returning the order that should be between them.
+         * order by:
+         *      position
+         *      closing tag has precedence over openning tag (unless it is the same tag)
+         *      tags that are enclosed in others should appear later if openning tag, or first if closing tag
+         *      lexicographical sort. openning tag and closing tag in reverse so that one tag will be contained in the other and not each contain the other partially
+         * @param o - the other tag object to compare to
+         * @return the order in between this object and the other
+         */
         @Override
         public int compareTo(Tag o) {
             return ComparisonChain.start()
@@ -139,6 +149,10 @@ public class StringBlock {
                 .result();
         }
 
+        /**
+         * formats the tag value and attributes according to whether the tag is an openning or closing tag
+         * @return the formatted tag value as a string
+         */
         @Override
         public String toString() {
             // "tag" can either be just the tag or have the form "tag;attr1=value1;attr2=value2;[...]".
@@ -212,6 +226,11 @@ public class StringBlock {
         }
     }
 
+    /**
+     *
+     * @param styledString - the raw string with its corresponding styling tags and their locations
+     * @return a formatted styled string that contains the styling tag in the correct locations
+     */
     String processStyledString(StyledString styledString) {
 
         ArrayList<Tag> sortedTagsList = new ArrayList<>();
@@ -238,21 +257,12 @@ public class StringBlock {
         int lastIndex = 0;
         for (Tag tag : sortedTagsList) {
             string.append(ResXmlEncoders.escapeXmlChars(raw.substring(lastIndex, tag.position)));
-            string.append(tag.toString());
+            string.append(tag);
             lastIndex = tag.position;
         }
         string.append(ResXmlEncoders.escapeXmlChars(raw.substring(lastIndex)));
 
         return string.toString();
-    }
-
-    /**
-     * Not yet implemented.
-     *
-     * Returns string with style information (if any).
-     */
-    public CharSequence get(int index) {
-        return getString(index);
     }
 
     /**
@@ -275,48 +285,6 @@ public class StringBlock {
 
         StyledString styledString = new StyledString(raw, style);
         return processStyledString(styledString);
-    }
-
-    private void outputStyleTag(String tag, StringBuilder builder, boolean close) {
-        builder.append('<');
-        if (close) {
-            builder.append('/');
-        }
-
-        int pos = tag.indexOf(';');
-        if (pos == -1) {
-            builder.append(tag);
-        } else {
-            builder.append(tag.substring(0, pos));
-            if (!close) {
-                boolean loop = true;
-                while (loop) {
-                    int pos2 = tag.indexOf('=', pos + 1);
-
-                    // malformed style information will cause crash. so
-                    // prematurely end style tags, if recreation
-                    // cannot be created.
-                    if (pos2 != -1) {
-                        builder.append(' ').append(tag.substring(pos + 1, pos2)).append("=\"");
-                        pos = tag.indexOf(';', pos2 + 1);
-
-                        String val;
-                        if (pos != -1) {
-                            val = tag.substring(pos2 + 1, pos);
-                        } else {
-                            loop = false;
-                            val = tag.substring(pos2 + 1);
-                        }
-
-                        builder.append(ResXmlEncoders.escapeXmlChars(val)).append('"');
-                    } else {
-                        loop = false;
-                    }
-
-                }
-            }
-        }
-        builder.append('>');
     }
 
     /**

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
@@ -18,6 +18,7 @@ package brut.androlib.res.decoder;
 
 import brut.androlib.res.xml.ResXmlEncoders;
 import brut.util.ExtDataInput;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.base.Splitter.MapSplitter;
 import com.google.common.collect.ComparisonChain;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ComparisonChain;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringJoiner;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
@@ -18,12 +18,21 @@ package brut.androlib.res.decoder;
 
 import brut.androlib.res.xml.ResXmlEncoders;
 import brut.util.ExtDataInput;
-import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
+import com.google.common.base.Splitter.MapSplitter;
+import com.google.common.collect.ComparisonChain;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.charset.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.Ordering.explicit;
+import static java.util.Comparator.naturalOrder;
+import static java.util.Comparator.reverseOrder;
 
 public class StringBlock {
 

--- a/brut.apktool/apktool-lib/src/test/resources/aapt1/testapp/res/values-mcc001/strings.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/aapt1/testapp/res/values-mcc001/strings.xml
@@ -42,4 +42,5 @@ bar"</string>
     <string name="test_string40">[<font size="17">]Ţåþ ţö ţýþé þåššŵöŕð one two three</font></string>
     <string name="test_string41"><font size="17">[Ţåþ ţö ţýþé þåššŵöŕð one two three]</font></string>
     <string name="test_string42">🔆</string>
+    <string name="test_string43"><ul> <li><b>aaaaa aa aaaaa</b> – aaaaaaa aaaaaaaaaa aa aaaaaaaa aaaaaa aaaaa (aaaa) aaaa aaaaaaaaa aaaaa aa aaaaaaaaa aaaaaaa aaaa</li> <li><b>aaaaaaaaa aaaaaaaaaaaaaaa aaaaaaaa</b> – aaaaaaa aaaaaaaaaa aaaaaaaaa aaaa aaaaaa aa aaaa aaaa aaaa aaaa aaaaaaa aaaaaaaaaaaaa, aaaaaa aaa aaaaaaaaaa (aaa) aaaaaaaaaaaaaaa</li> <li><b>aaaaaaaaaaa aaaaaa aaaaaaaaaa</b> – aaaaaaaaaa aaaa aaaaaa aa a aaa aa aaaaaa aaa aaaaaaa (aaaaa aaaaaaaa) aaaaaaaa aa aaaaaa aaaaa aaa aaaa</li> </ul></string>
 </resources>

--- a/brut.apktool/apktool-lib/src/test/resources/aapt2/testapp/res/values/strings.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/aapt2/testapp/res/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="app_name">testapp</string>
     <string name="long_string_32767" />
     <string name="surrogate_issue_2299">🔆</string>
+    <string name="test_string43"><ul> <li><b>aaaaa aa aaaaa</b> – aaaaaaa aaaaaaaaaa aa aaaaaaaa aaaaaa aaaaa (aaaa) aaaa aaaaaaaaa aaaaa aa aaaaaaaaa aaaaaaa aaaa</li> <li><b>aaaaaaaaa aaaaaaaaaaaaaaa aaaaaaaa</b> – aaaaaaa aaaaaaaaaa aaaaaaaaa aaaa aaaaaa aa aaaa aaaa aaaa aaaa aaaaaaa aaaaaaaaaaaaa, aaaaaa aaa aaaaaaaaaa (aaa) aaaaaaaaaaaaaaa</li> <li><b>aaaaaaaaaaa aaaaaa aaaaaaaaaa</b> – aaaaaaaaaa aaaa aaaaaa aa a aaa aa aaaaaa aaa aaaaaaa (aaaaa aaaaaaaa) aaaaaaaa aa aaaaaa aaaaa aaa aaaa</li> </ul></string>
 </resources>


### PR DESCRIPTION
fixes issue where strings.xml had an entry:
<string name="test_apktool">" <ul> <li><b>aaaaa aa aaaaa</b> – aaaaaaa aaaaaaaaaa aa aaaaaaaa aaaaaa aaaaa (aaaa) aaaa aaaaaaaaa aaaaa aa aaaaaaaaa aaaaaaa aaaa</li>\n <li><b>aaaaaaaaa aaaaaaaaaaaaaaa aaaaaaaa</b> – aaaaaaa aaaaaaaaaa aaaaaaaaa aaaa aaaaaa aa aaaa aaaa aaaa aaaa aaaaaaa aaaaaaaaaaaaa, aaaaaa aaa aaaaaaaaaa (aaa) aaaaaaaaaaaaaaa</li>\n <li><b>aaaaaaaaaaa aaaaaa aaaaaaaaaa</b> – aaaaaaaaaa aaaa aaaaaa aa a aaa aa aaaaaa aaa aaaaaaa (aaaaa aaaaaaaa) aaaaaaaa aa aaaaaa aaaaa aaa aaaa</li> </ul> "</string>

uses code from https://github.com/google/bundletool/blob/06296d8ec009af6ec7d09f6da2cf54994fa3a89b/src/main/java/com/android/tools/build/bundletool/model/utils/xmlproto/XmlProtoPrintUtils.java

changed `getHTML()` to use code from bundletool to insert the HTML tags into the string.
fixed bug from bundletool in `Tag.compareTo()` and called `ResXmlEncoders.escapeXmlChars()` on the strings.

fixes: #2632 