### PR TITLE
DNM use smali from https://github.com/JesusFreke/smali/pull/816, fixes "Failure to verify dex file 'classes.dex': Non-zero padding before section of..."

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ buildscript {
         ibotEmail = 'connor.tumbleson@gmail.com'
 
         depends = [
-                baksmali       : 'org.smali:baksmali:2.5.2',
                 commons_cli    : 'commons-cli:commons-cli:1.4',
                 commons_io     : 'commons-io:commons-io:2.11.0',
                 commons_lang   : 'org.apache.commons:commons-lang3:3.12.0',
@@ -32,9 +31,10 @@ buildscript {
                 junit          : 'junit:junit:4.13.2',
                 proguard_gradle: 'com.guardsquare:proguard-gradle:7.1.1',
                 snakeyaml      : 'org.yaml:snakeyaml:1.29:android',
-                smali          : 'org.smali:smali:2.5.2',
                 xmlpull        : 'xpp3:xpp3:1.1.4c',
                 xmlunit        : 'xmlunit:xmlunit:1.6',
+                smali          : 'org.smali:smali',
+                baksmali       : 'org.smali:baksmali'
         ]
     }
 
@@ -45,6 +45,7 @@ buildscript {
     dependencies {
         classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
         classpath "gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.16.1"
+        
     }
 }
 
@@ -54,6 +55,11 @@ version = '2.5.1'
 def suffix = 'SNAPSHOT'
 
 defaultTasks 'build', 'shadowJar', 'proguard'
+
+subprojects {
+    tasks.withType(Javadoc).all { enabled = false }
+}
+
 
 allprojects {
     apply plugin: 'java'
@@ -78,7 +84,26 @@ allprojects {
             "licenseMain",
             "licenseTest"
     ]
+
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        implementation('org.smali:smali') {
+            version {
+                branch = 'master'
+            }
+       }
+        implementation('org.smali:baksmali') {
+            version {
+                branch = 'master'
+            }
+       }
+    }   
+
 }
+
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = StandardCharsets.UTF_8.toString()

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,9 @@
-include 'brut.j.common',
-        'brut.j.util',
-        'brut.j.dir',
-        'brut.apktool:apktool-lib',
-        'brut.apktool:apktool-cli'
+sourceControl {
+    gitRepository("https://github.com/robertsmd/smali.git") {
+	producesModule("org.smali:smali")
+	producesModule("org.smali:baksmali")
+    }
+}
+
+include 'brut.j.common', 'brut.j.util', 'brut.j.dir', 'brut.apktool:apktool-lib', 'brut.apktool:apktool-cli'
+


### PR DESCRIPTION
ran into this issue https://github.com/JesusFreke/smali/issues/815
which is fixed in this yet unmerged PR https://github.com/JesusFreke/smali/pull/816/files

this PR is my shoddy attempt at bringing in the fix to ApkTool
I have never really used gradle before so while this successfully builds, and fixes the issue, but I'm sure I'm breaking some gradle rules all over the place and the formatting is messy in places. 

My goal with this is mainly to make it available to others facing the same issue.
If the maintainers would like to see this merged for one reason or another, I am happy to clean it up a bit. 

Had to force disable javadoc building, as those failed for some reason I could not figure out.

## How to use this PR
### important: gradle 4.10 or later required for the git repo dependency used here
```
git clone git@github.com:SolidHal/Apktool.git
cd ApkTool
checkout smali-patch
./gradlew shadowJar
sudo cp ./brut.apktool/apktool-cli/build/libs/apktool-cli-all.jar /usr/local/bin/apktool.jar
```