### PR TITLE
fix: decoding references to private resources

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResResSpec.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResResSpec.java
@@ -18,6 +18,7 @@ package brut.androlib.res.data;
 
 import brut.androlib.AndrolibException;
 import brut.androlib.err.UndefinedResObjectException;
+import brut.androlib.res.decoder.ARSCDecoder;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.LinkedHashMap;
@@ -28,11 +29,13 @@ import java.util.Set;
 public class ResResSpec {
     private final ResID mId;
     private final String mName;
+    private final int mFlags;
     private final ResPackage mPackage;
     private final ResTypeSpec mType;
     private final Map<ResConfigFlags, ResResource> mResources = new LinkedHashMap<>();
 
-    public ResResSpec(ResID id, String name, ResPackage pkg, ResTypeSpec type) {
+    public ResResSpec(ResID id, String name, int mFlags, ResPackage pkg, ResTypeSpec type) {
+        this.mFlags = mFlags;
         this.mId = id;
         String cleanName;
 
@@ -72,13 +75,19 @@ public class ResResSpec {
         return mResources.containsKey(new ResConfigFlags());
     }
 
+    public boolean isPublicResource() {
+        return (getFlags() & ARSCDecoder.ENTRY_FLAG_PUBLIC) != 0;
+    }
+
     public String getFullName(ResPackage relativeToPackage, boolean excludeType) {
         return getFullName(getPackage().equals(relativeToPackage), excludeType);
     }
 
     public String getFullName(boolean excludePackage, boolean excludeType) {
-        return (excludePackage ? "" : getPackage().getName() + ":")
-                + (excludeType ? "" : getType().getName() + "/") + getName();
+        String privateSuffix = isPublicResource() ? "" : "*";
+        String packageName = excludePackage ? "" : getPackage().getName() + ":";
+        return (packageName.isEmpty() ? "" : privateSuffix + packageName)
+            + (excludeType ? "" : getType().getName() + "/") + getName();
     }
 
     public ResID getId() {
@@ -95,6 +104,10 @@ public class ResResSpec {
 
     public ResTypeSpec getType() {
         return mType;
+    }
+
+    public int getFlags() {
+        return mFlags;
     }
 
     public boolean isDummyResSpec() {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
@@ -309,12 +309,12 @@ public class ARSCDecoder {
             if (spec.isDummyResSpec()) {
                 removeResSpec(spec);
 
-                spec = new ResResSpec(resId, mSpecNames.getString(specNamesId), mPkg, mTypeSpec);
+                spec = new ResResSpec(resId, mSpecNames.getString(specNamesId), entryData.mFlags, mPkg, mTypeSpec);
                 mPkg.addResSpec(spec);
                 mTypeSpec.addResSpec(spec);
             }
         } else {
-            spec = new ResResSpec(resId, mSpecNames.getString(specNamesId), mPkg, mTypeSpec);
+            spec = new ResResSpec(resId, mSpecNames.getString(specNamesId), entryData.mFlags, mPkg, mTypeSpec);
             mPkg.addResSpec(spec);
             mTypeSpec.addResSpec(spec);
         }
@@ -511,7 +511,7 @@ public class ARSCDecoder {
                 continue;
             }
 
-            ResResSpec spec = new ResResSpec(new ResID(resId | i), "APKTOOL_DUMMY_" + Integer.toHexString(i), mPkg, mTypeSpec);
+            ResResSpec spec = new ResResSpec(new ResID(resId | i), "APKTOOL_DUMMY_" + Integer.toHexString(i), ENTRY_FLAG_PUBLIC, mPkg, mTypeSpec);
 
             // If we already have this resID dont add it again.
             if (! mPkg.hasResSpec(new ResID(resId | i))) {
@@ -575,7 +575,7 @@ public class ARSCDecoder {
     private final HashMap<Integer, ResTypeSpec> mResTypeSpecs = new HashMap<>();
 
     private final static short ENTRY_FLAG_COMPLEX = 0x0001;
-    private final static short ENTRY_FLAG_PUBLIC = 0x0002;
+    public final static short ENTRY_FLAG_PUBLIC = 0x0002;
     private final static short ENTRY_FLAG_WEAK = 0x0004;
 
     public static class Header {


### PR DESCRIPTION
fixed #2033, #2637 of error 
`error: resource <name> is private.`
Use `*` before resource name if rererence to private resources.
Expample:
before fix
` <color name="gm3_ref_palette_dynamic_tertiary900">@android:color/Indigo_700</color>`
after fix
` <color name="gm3_ref_palette_dynamic_tertiary900">@*android:color/Indigo_700</color>`