### PR TITLE
Fixes facebook apk deconstruction

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResValueFactory.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResValueFactory.java
@@ -104,12 +104,12 @@ public class ResValueFactory {
             return new ResPluralsValue(parentVal, items);
         }
 
-        if (ResTypeSpec.RES_TYPE_NAME_STYLES.equals(resTypeName)) {
-            return new ResStyleValue(parentVal, items, this);
-        }
-
         if (ResTypeSpec.RES_TYPE_NAME_ATTR.equals(resTypeName)) {
             return new ResAttr(parentVal, 0, null, null, null);
+        }
+        
+        if (resTypeName.startsWith(ResTypeSpec.RES_TYPE_NAME_STYLES)) {
+            return new ResStyleValue(parentVal, items, this);
         }
 
         throw new AndrolibException("unsupported res type name for bags. Found: " + resTypeName);


### PR DESCRIPTION
Fixes ApkTool can't deconstruct apk: https://apkpure.com/facebook/com.facebook.katana
fixes #1719
