### PR TITLE
support sparse flag

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
@@ -33,6 +33,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -250,8 +251,7 @@ public class ARSCDecoder {
         /* reserved */mIn.skipBytes(2);
         int entryCount = mIn.readInt();
         int entriesStart = mIn.readInt();
-        mMissingResSpecs = new boolean[entryCount];
-        Arrays.fill(mMissingResSpecs, true);
+        mMissingResSpecMap = new LinkedHashMap();
 
         ResConfigFlags flags = readConfigFlags();
         int position = (mHeader.startPosition + entriesStart) - (entryCount * 4);
@@ -263,10 +263,20 @@ public class ARSCDecoder {
             mIn.skipBytes(position - mCountIn.getCount());
         }
 
-        if (typeFlags == 1) {
+        if ((typeFlags & 0x01) != 0) {
             LOGGER.info("Sparse type flags detected: " + mTypeSpec.getName());
+        }else{
+            // LOGGER.info("Not sparse type flags detected: " + mTypeSpec.getName());
         }
-        int[] entryOffsets = mIn.readIntArray(entryCount);
+
+        HashMap<Integer, Integer> entryOffsetMap = new LinkedHashMap();
+        for (int i = 0; i < entryCount; i++){
+            if ((typeFlags & 0x01) != 0) {
+                entryOffsetMap.put(mIn.readUnsignedShort(), mIn.readUnsignedShort());
+            }else{
+                entryOffsetMap.put(i, mIn.readInt());
+            }
+        }
 
         if (flags.isInvalid) {
             String resName = mTypeSpec.getName() + flags.getQualifiers();
@@ -278,23 +288,13 @@ public class ARSCDecoder {
         }
 
         mType = flags.isInvalid && !mKeepBroken ? null : mPkg.getOrCreateConfig(flags);
-        HashMap<Integer, EntryData> offsetsToEntryData = new HashMap<>();
 
-        for (int offset : entryOffsets) {
-            if (offset == -1 || offsetsToEntryData.containsKey(offset)) {
-                continue;
-            }
-
-            offsetsToEntryData.put(offset, readEntryData());
-        }
-
-        for (int i = 0; i < entryOffsets.length; i++) {
-            if (entryOffsets[i] != -1) {
-                mMissingResSpecs[i] = false;
-                mResId = (mResId & 0xffff0000) | i;
-                EntryData entryData = offsetsToEntryData.get(entryOffsets[i]);
-                readEntry(entryData);
-            }
+        for (int i : entryOffsetMap.keySet()){
+            int offset = entryOffsetMap.get(i);
+            if (offset == -1) continue;
+            mMissingResSpecMap.put(i, false);
+            mResId = (mResId & 0xffff0000) | i;
+            readEntry(readEntryData());
         }
 
         return mType;
@@ -533,10 +533,8 @@ public class ARSCDecoder {
     private void addMissingResSpecs() throws AndrolibException {
         int resId = mResId & 0xffff0000;
 
-        for (int i = 0; i < mMissingResSpecs.length; i++) {
-            if (!mMissingResSpecs[i]) {
-                continue;
-            }
+        for (int i : mMissingResSpecMap.keySet()){
+            if (mMissingResSpecMap.get(i)) continue;
 
             ResResSpec spec = new ResResSpec(new ResID(resId | i), "APKTOOL_DUMMY_" + Integer.toHexString(i), mPkg, mTypeSpec);
 
@@ -598,7 +596,7 @@ public class ARSCDecoder {
     private ResType mType;
     private int mResId;
     private int mTypeIdOffset = 0;
-    private boolean[] mMissingResSpecs;
+    private HashMap<Integer, Boolean> mMissingResSpecMap;
     private final HashMap<Integer, ResTypeSpec> mResTypeSpecs = new HashMap<>();
 
     private final static short ENTRY_FLAG_COMPLEX = 0x0001;


### PR DESCRIPTION
[ResourcesType.h (Android 7.1.2)](http://www.aospxref.com/android-7.1.2_r39/xref/frameworks/base/include/androidfw/ResourceTypes.h#1334):
```cpp
struct ResTable_type
{
    struct ResChunk_header header;

    enum {
        NO_ENTRY = 0xFFFFFFFF
    };
    
    // The type identifier this chunk is holding.  Type IDs start
    // at 1 (corresponding to the value of the type bits in a
    // resource identifier).  0 is invalid.
    uint8_t id;
    
    // Must be 0.
    uint8_t res0;
    // Must be 0.
    uint16_t res1;
    
    // Number of uint32_t entry indices that follow.
    uint32_t entryCount;

    // Offset from header where ResTable_entry data starts.
    uint32_t entriesStart;
    
    // Configuration this collection of entries is designed for.
    ResTable_config config;
};
```

[Resources.h (Android 8.0.0)](http://www.aospxref.com/android-8.0.0_r36/xref/frameworks/base/libs/androidfw/include/androidfw/ResourceTypes.h#1364):
```cpp
struct ResTable_type
{
    struct ResChunk_header header;

    enum {
        NO_ENTRY = 0xFFFFFFFF
    };
    
    // The type identifier this chunk is holding.  Type IDs start
    // at 1 (corresponding to the value of the type bits in a
    // resource identifier).  0 is invalid.
    uint8_t id;
    
    enum {
        // If set, the entry is sparse, and encodes both the entry ID and offset into each entry,
        // and a binary search is used to find the key. Only available on platforms >= O.
        // Mark any types that use this with a v26 qualifier to prevent runtime issues on older
        // platforms.
        FLAG_SPARSE = 0x01,
    };
    uint8_t flags;

    // Must be 0.
    uint16_t reserved;
    
    // Number of uint32_t entry indices that follow.
    uint32_t entryCount;

    // Offset from header where ResTable_entry data starts.
    uint32_t entriesStart;

    // Configuration this collection of entries is designed for. This must always be last.
    ResTable_config config;
};
```

If set, we can read it by this way:
```kotlin
val offsetMap = mutableMapOf<Int, Int>()
for (i in 0 until header.entryCount)
    offsetMap[i] = reader.int
```

If set, the entry is sparse, and encodes both the entry ID and offset into each entry, so we can read it by this way
```kotlin
val offsetMap = mutableMapOf<Int, Int>()
for (i in 0 until header.entryCount)
    if (header.flags.isSparse) offsetMap[reader.uShort.toInt()] = (reader.uShort * 4u).toInt()
    else offsetMap[i] = reader.int
```

when FLAG_SPARSE is not set, we can get offset by read a int.
when FLAG_SPARSE is set, we can get entry id by read a unsigned short, then get offset by read a unsigned short;