### PR TITLE
Make default framework location detection on Linux XDG compliant

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
@@ -974,7 +974,12 @@ final public class AndrolibResources {
             } else if (OSDetection.isWindows()) {
                 path = parentPath.getAbsolutePath() + String.format("%1$sAppData%1$sLocal%1$sapktool%1$sframework", File.separatorChar);
             } else {
-                path = parentPath.getAbsolutePath() + String.format("%1$s.local%1$sshare%1$sapktool%1$sframework", File.separatorChar);
+                String xdgDataFolder = System.getenv("XDG_DATA_HOME");
+                if (xdgDataFolder != null) {
+                    path = xdgDataFolder + String.format("%1$sapktool%1$sframework", File.separatorChar);
+                } else {
+                    path = parentPath.getAbsolutePath() + String.format("%1$s.local%1$sshare%1$sapktool%1$sframework", File.separatorChar);
+                }
             }
         }
 


### PR DESCRIPTION
As per the [XDG basedir spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html):
> Environment variables: [...] `$XDG_DATA_HOME` defines the base directory relative to which user-specific data files should be stored. If `$XDG_DATA_HOME` is either not set or empty, a default equal to `$HOME/.local/share` should be used. 

Implementing this, makes Apktool work in special environments (such as Flatpak) which by default set XDG_DATA_HOME to something else, without the need to override the path with `--frame-dir`

As far as I know, the BSDs also try to adhere to the XDG spec, so this should be beneficial for them too.