### PR TITLE
Fix « doNotCompress » in case of obfuscated resources.

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/Androlib.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/Androlib.java
@@ -184,6 +184,9 @@ public class Androlib {
 
                     if (ext.isEmpty() || !NO_COMPRESS_PATTERN.matcher(ext).find()) {
                         ext = file;
+                        if (mAndRes.ObfFiles.containsKey(ext)) {
+                            ext = mAndRes.ObfFiles.get(ext);
+                        }
                     }
                     if (!uncompressedFilesOrExts.contains(ext)) {
                         uncompressedFilesOrExts.add(ext);

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
@@ -247,7 +247,7 @@ final public class AndrolibResources {
 
             LOGGER.info("Decoding file-resources...");
             for (ResResource res : pkg.listFiles()) {
-                fileDecoder.decode(res, in, out);
+                fileDecoder.decode(res, in, out, ObfFiles);
             }
 
             LOGGER.info("Decoding values */* XMLs...");
@@ -1040,6 +1040,8 @@ final public class AndrolibResources {
     }
 
     public BuildOptions buildOptions;
+
+    public Map<String, String> ObfFiles = new HashMap();
 
     // TODO: dirty static hack. I have to refactor decoding mechanisms.
     public static boolean sKeepBroken = false;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResFileDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResFileDecoder.java
@@ -27,6 +27,7 @@ import brut.directory.Directory;
 import brut.directory.DirectoryException;
 
 import java.io.*;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -37,10 +38,11 @@ public class ResFileDecoder {
         this.mDecoders = decoders;
     }
 
-    public void decode(ResResource res, Directory inDir, Directory outDir)
+    public void decode(ResResource res, Directory inDir, Directory outDir, Map<String, String> obfFiles)
             throws AndrolibException {
 
         ResFileValue fileValue = (ResFileValue) res.getValue();
+        String inFileFullName = fileValue.toString();
         String inFileName = fileValue.getStrippedPath();
         String outResName = res.getFilePath();
         String typeName = res.getResSpec().getType().getName();
@@ -53,6 +55,11 @@ public class ResFileDecoder {
         } else {
             ext = inFileName.substring(extPos).toLowerCase();
             outFileName = outResName + ext;
+        }
+
+        String outFileFullName = "res/"+outFileName;
+        if (!inFileFullName.equals(outFileFullName)) {
+            obfFiles.put(inFileFullName, outFileFullName);
         }
 
         try {


### PR DESCRIPTION
In case of obfuscated resources, the list of uncompressed files (doNotCompress) is populated with the names of the obfuscated files instead of the names of the decoded files! 
This is a quick fix.