### PR TITLE
fix: --no-src should take precedence over --only-main-classes

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
@@ -180,6 +180,9 @@ public class ApkDecoder {
         if (mode != DECODE_SOURCES_NONE && mode != DECODE_SOURCES_SMALI && mode != DECODE_SOURCES_SMALI_ONLY_MAIN_CLASSES) {
             throw new AndrolibException("Invalid decode sources mode: " + mode);
         }
+        if (mDecodeSources == DECODE_SOURCES_NONE && mode == DECODE_SOURCES_SMALI_ONLY_MAIN_CLASSES) {
+            return;
+        }
         mDecodeSources = mode;
     }
 


### PR DESCRIPTION
**Problem**: when both `--no-src` and `--only-main-classes` are passed, `--only-main-classes` takes precedence and dex files end up getting decompiled. I think `--no-src` is quite explicit and shouldn't be ignored.