### PR TITLE
fix:  res/layout/(name removed).xml: Invalid file name

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResResSpec.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResResSpec.java
@@ -36,11 +36,14 @@ public class ResResSpec {
         this.mId = id;
         String cleanName;
 
+        if (name == null || name.isEmpty() || name.equals("(name removed)"))
+            name = "APKTOOL_DUMMYVAL_" + id.toString();
+
         ResResSpec resResSpec = type.getResSpecUnsafe(name);
         if (resResSpec != null) {
             cleanName = String.format("APKTOOL_DUPLICATE_%s_%s", type, id.toString());
         } else {
-            cleanName = ((name == null || name.isEmpty()) ? ("APKTOOL_DUMMYVAL_" + id.toString()) : name);
+            cleanName = name;
         }
 
         this.mName = cleanName;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResResSpec.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResResSpec.java
@@ -36,14 +36,13 @@ public class ResResSpec {
         this.mId = id;
         String cleanName;
 
-        if (name == null || name.isEmpty() || name.equals("(name removed)"))
-            name = "APKTOOL_DUMMYVAL_" + id.toString();
+        name = (("(name removed)".equals(name)) ? null : name);
 
         ResResSpec resResSpec = type.getResSpecUnsafe(name);
         if (resResSpec != null) {
             cleanName = String.format("APKTOOL_DUPLICATE_%s_%s", type, id.toString());
         } else {
-            cleanName = name;
+            cleanName = ((name == null || name.isEmpty()) ? ("APKTOOL_DUMMYVAL_" + id.toString()) : name);
         }
 
         this.mName = cleanName;


### PR DESCRIPTION

**problem**: If the names of some resources have been deleted, we get an error when building

```bash
W: res/layout/(name removed).xml: Invalid file name: must contain only [a-zA-Z0-9$_.]
brut.androlib.AndrolibException: brut.common.BrutException: could not exec (exit code = 1)
```
For example, for the [WhatsApp business](https://www.apkmirror.com/apk/whatsapp-inc/whatsapp-business/whatsapp-business-2-22-24-18-release/whatsapp-business-2-22-24-18-2-android-apk-download/)

**reason**: aapt2 return "(name removed)" for deleted resource names