### PR TITLE
Update Windows helper script to handle /c properly.

### DIFF
--- a/scripts/windows/apktool.bat
+++ b/scripts/windows/apktool.bat
@@ -39,4 +39,4 @@ if "%ATTR:~0,1%"=="-" if "%~x1"==".apk" (
 "%java_exe%" -jar -Duser.language=en -Dfile.encoding=UTF8 "%~dp0%BASENAME%%max%.jar" %fastCommand% %*
 
 rem Pause when ran non interactively
-for /f "tokens=2" %%# in ("%cmdcmdline%") do if /i "%%#" equ "/c" pause
+for %%i in (%cmdcmdline%) do if /i "%%~i"=="/c" pause & exit /b


### PR DESCRIPTION
A new version of apktool.bat is causing my scripts to fail. For some reason, a .bat ending with `for /f "tokens=x" ...`, when the actual number of tokens is less than expected sets %errorlevel% to '1'. What's funny is that `echo %errorlevel%` prints '0', and even putting `rem` at the end of the file works. Only calling a .bat whose last line is `for /f "tokens=x" ...` from another .bat causes the issue. I had a hard time debugging 😫.
Apart from that, it's just an incorrect way to check for '/c' argument.