### PR TITLE
Restructure Testable Java versions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
-        java: [ 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 ]
+        java: [ 8, 11, 17, 18, 19 ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
* Track older LTS
* Track recent versions
* Fixes #2976

---

So keep 8, 11 and 17 as LTS - then add 18/19 as recent.