### PR TITLE
fix: accept empty resources.arsc

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/Androlib.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/Androlib.java
@@ -776,7 +776,7 @@ public class Androlib {
 
     public boolean isFrameworkApk(ResTable resTable) {
         for (ResPackage pkg : resTable.listMainPackages()) {
-            if (pkg.getId() < 64) {
+            if (pkg.getId() > 0 && pkg.getId() < 64) {
                 return true;
             }
         }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/mod/SmaliMod.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/mod/SmaliMod.java
@@ -30,7 +30,7 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 
 public class SmaliMod {
-    public static boolean assembleSmaliFile(File smaliFile,DexBuilder dexBuilder, int apiLevel, boolean verboseErrors,
+    public static boolean assembleSmaliFile(File smaliFile, DexBuilder dexBuilder, int apiLevel, boolean verboseErrors,
                                             boolean printTokens) throws IOException, RecognitionException {
 
         CommonTokenStream tokens;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
@@ -66,7 +66,7 @@ final public class AndrolibResources {
 
         switch (pkgs.length) {
             case 0:
-                pkg = null;
+                pkg = new ResPackage(resTable, 0, null);
                 break;
             case 1:
                 pkg = pkgs[0];
@@ -78,10 +78,6 @@ final public class AndrolibResources {
             default:
                 pkg = selectPkgWithMostResSpecs(pkgs);
                 break;
-        }
-
-        if (pkg == null) {
-            throw new AndrolibException("arsc files with zero packages or no arsc file found.");
         }
 
         resTable.addPackage(pkg, true);
@@ -168,9 +164,11 @@ final public class AndrolibResources {
         resTable.setPackageId(resPackage.getId());
         resTable.setPackageOriginal(pkgOriginal);
 
-        // 1) Check if pkgOriginal === mPackageRenamed
-        // 2) Check if pkgOriginal is ignored via IGNORED_PACKAGES
-        if (pkgOriginal.equalsIgnoreCase(mPackageRenamed) || (Arrays.asList(IGNORED_PACKAGES).contains(pkgOriginal))) {
+        // 1) Check if pkgOriginal is null (empty resources.arsc)
+        // 2) Check if pkgOriginal === mPackageRenamed
+        // 3) Check if pkgOriginal is ignored via IGNORED_PACKAGES
+        if (pkgOriginal == null || pkgOriginal.equalsIgnoreCase(mPackageRenamed)
+                || (Arrays.asList(IGNORED_PACKAGES).contains(pkgOriginal))) {
             LOGGER.info("Regular manifest package...");
         } else {
             LOGGER.info("Renamed manifest package found! Replacing " + mPackageRenamed + " with " + pkgOriginal);
@@ -708,7 +706,7 @@ final public class AndrolibResources {
         if (withResources) {
             axmlParser.setAttrDecoder(new ResAttrDecoder());
         }
-        decoders.setDecoder("xml", new XmlPullStreamDecoder(axmlParser,getResXmlSerializer()));
+        decoders.setDecoder("xml", new XmlPullStreamDecoder(axmlParser, getResXmlSerializer()));
 
         return new Duo<>(new ResFileDecoder(decoders), axmlParser);
     }
@@ -772,7 +770,7 @@ final public class AndrolibResources {
         }
     }
 
-    private ResPackage[] getResPackagesFromApk(ExtFile apkFile,ResTable resTable, boolean keepBroken)
+    private ResPackage[] getResPackagesFromApk(ExtFile apkFile, ResTable resTable, boolean keepBroken)
             throws AndrolibException {
         try {
             Directory dir = apkFile.getDirectory();


### PR DESCRIPTION
Apktool treats APKs with stub resources.arsc like criminals:
```
I: Loading resource table...
Exception in thread "main" brut.androlib.AndrolibException: arsc files with zero packages or no arsc file found.
        at brut.androlib.res.AndrolibResources.loadMainPkg(AndrolibResources.java:84)
        at brut.androlib.res.AndrolibResources.getResTable(AndrolibResources.java:56)
        at brut.androlib.Androlib.getResTable(Androlib.java:74)
        at brut.androlib.ApkDecoder.getResTable(ApkDecoder.java:270)
        at brut.androlib.ApkDecoder.decode(ApkDecoder.java:110)
        at brut.apktool.Main.cmdDecode(Main.java:175)
        at brut.apktool.Main.main(Main.java:79)
```

But in fact, those APKs are valid and very common among overlay APKs, but here's a non-overlay example as well:
https://drive.google.com/file/d/1seAnndB9cH6_qo04FC7_1JPW5CVXLMnt/view

This change creates a "fake ResPackage", exactly as done in decodeManifest, if resources.arsc was loaded but contains 0 packages.
The output is valid and recompilation already produces an identical 40 bytes stub resources.arsc without any additional changes needed.

P.S. also fixed a few missing spaces for cleanliness.