### PR TITLE
fix: zip entry name

### DIFF
--- a/brut.j.dir/src/main/java/brut/directory/ZipUtils.java
+++ b/brut.j.dir/src/main/java/brut/directory/ZipUtils.java
@@ -56,9 +56,10 @@ public class ZipUtils {
 
     private static void processFolder(final File folder, final ZipOutputStream zipOutputStream, final int prefixLength)
             throws BrutException, IOException {
+        final File baseFolder = new File(folder.getPath().substring(0, prefixLength - 1));
         for (final File file : folder.listFiles()) {
             if (file.isFile()) {
-                final String cleanedPath = BrutIO.sanitizeUnknownFile(folder, file.getPath().substring(prefixLength));
+                final String cleanedPath = BrutIO.sanitizeUnknownFile(baseFolder, file.getPath().substring(prefixLength));
                 final ZipEntry zipEntry = new ZipEntry(BrutIO.normalizePath(cleanedPath));
 
                 // aapt binary by default takes in parameters via -0 arsc to list extensions that shouldn't be


### PR DESCRIPTION
In a unity3d game, if there is a resource directory `assets/AssetBundles/Assets`, for example

```
assets
├── AssetBundles
│   ├── Assets
│   │   └── a.txt
│   └── b.json
```

would result in an entry `Assets/AssetBundles/b.json` in the apk:

```
$ unzip -l demo.apk | grep -i assets/AssetBundles
         0 04-07-2023 23:03 assets/AssetBundles/Assets/a.txt
         0 04-07-2023 23:10 Assets/AssetBundles/b.json
```