### PR TITLE
Create gh-actions-cache.yml

### DIFF
--- a/.github/workflows/gh-actions-cache.yml
+++ b/.github/workflows/gh-actions-cache.yml
@@ -1,0 +1,33 @@
+name: cleanup caches by a branch
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+          
+          REPO=${{ github.repository }}
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys. 
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
A repository can have multiple pull requests with their own caches, leading to a shortage of cache storage. The cache eviction policy automatically removes the oldest caches to make space. To prevent cache thrashing, workflows can be set up to delete caches faster than the eviction policy. This can be achieved using the gh-actions-cache CLI extension, which enables the deletion of caches for specific branches.