### PR TITLE
print aapt version

### DIFF
--- a/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
+++ b/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
@@ -312,6 +312,25 @@ public class Main {
 
     private static void _version() {
         System.out.println(Androlib.getVersion());
+        try {
+            System.out.print("Embedded aapt: ");
+            System.out.print(AaptManager.getAaptVersionString(AaptManager.getAapt1()));
+            System.out.print("Embedded aapt2: ");
+            System.out.print(AaptManager.getAaptVersionString(AaptManager.getAapt2()));
+            File aapt1 = AaptManager.findAaptInPath(1);
+            if (aapt1 != null) {
+                System.out.print(aapt1.getPath() + ": ");
+                System.out.print(AaptManager.getAaptVersionString(aapt1));
+            }
+            File aapt2 = AaptManager.findAaptInPath(2);
+            if (aapt2 != null) {
+                System.out.print(aapt2.getPath() + ": ");
+                System.out.print(AaptManager.getAaptVersionString(aapt2));
+            }
+        } catch (BrutException e) {
+            System.err.println(e.getMessage());
+            System.exit(1);
+        }
     }
 
     private static void _Options() {

--- a/brut.j.util/src/main/java/brut/util/OS.java
+++ b/brut.j.util/src/main/java/brut/util/OS.java
@@ -120,12 +120,10 @@ public class OS {
             StreamCollector collector = new StreamCollector(process.getInputStream());
             executor.execute(collector);
 
-            process.waitFor();
-            if (! executor.awaitTermination(15, TimeUnit.SECONDS)) {
-                executor.shutdownNow();
-                if (! executor.awaitTermination(5, TimeUnit.SECONDS)) {
-                    System.err.println("Stream collector did not terminate.");
-                }
+            process.waitFor(15, TimeUnit.SECONDS);
+            executor.shutdownNow();
+            if (! executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                System.err.println("Stream collector did not terminate.");
             }
             return collector.get();
         } catch (IOException | InterruptedException e) {


### PR DESCRIPTION
1. Correct OS.execAndReturn which always wait 15 seconds, even if the aapt process has been completed successfully
2. Add finding aapt executable in the PATH.
3. Print aapt version - embedded and in the path by "--version"  

With this patch `apktool --version` with print aapt versions complited momentally, without - each process run wait 15 sec. 