### PR TITLE
correct always wait 15 seconds

### DIFF
--- a/brut.j.util/src/main/java/brut/util/OS.java
+++ b/brut.j.util/src/main/java/brut/util/OS.java
@@ -120,12 +120,10 @@ public class OS {
             StreamCollector collector = new StreamCollector(process.getInputStream());
             executor.execute(collector);
 
-            process.waitFor();
-            if (! executor.awaitTermination(15, TimeUnit.SECONDS)) {
-                executor.shutdownNow();
-                if (! executor.awaitTermination(5, TimeUnit.SECONDS)) {
-                    System.err.println("Stream collector did not terminate.");
-                }
+            process.waitFor(15, TimeUnit.SECONDS);
+            executor.shutdownNow();
+            if (! executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                System.err.println("Stream collector did not terminate.");
             }
             return collector.get();
         } catch (IOException | InterruptedException e) {


### PR DESCRIPTION
Part for correct OS.execAndReturn which always wait 15 seconds, even if the aapt process has been completed successfully
from #3069 