### PR TITLE
build: lock gradle actions to specific versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,9 +75,9 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/wrapper-validation-action@v1.0.6
       - name: Build and test
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2.4.2
         with:
           arguments: build shadowJar proguard
 
@@ -94,7 +94,7 @@ jobs:
           distribution: 'zulu'
           java-version: 17
       - name: Build
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2.4.2
         with:
           arguments: build shadowJar proguard
       - name: Upload


### PR DESCRIPTION
I keep getting folks reaching out that the build script is vulnerable to x/y/z, despite the "v2" tag being moved/pointed to a non-vulnerable version of these dependencies.

So this should cause their automated scripts to realize no issue and save me having to triage the weekly email about security issues.