### PR TITLE
Deprecated SnakeYAML methods

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/meta/ClassSafeConstructor.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/meta/ClassSafeConstructor.java
@@ -19,6 +19,7 @@ package brut.androlib.meta;
 import org.yaml.snakeyaml.constructor.AbstractConstruct;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.error.YAMLException;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.ScalarNode;
 import org.yaml.snakeyaml.nodes.Tag;
@@ -29,6 +30,7 @@ public class ClassSafeConstructor extends Constructor {
     protected final List<Class<?>> allowableClasses = new ArrayList<>();
 
     public ClassSafeConstructor() {
+        super(new LoaderOptions());
         this.yamlConstructors.put(Tag.STR, new ConstructStringEx());
 
         this.allowableClasses.add(MetaInfo.class);

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/meta/EscapedStringRepresenter.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/meta/EscapedStringRepresenter.java
@@ -16,11 +16,13 @@
  */
 package brut.androlib.meta;
 
+import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.representer.Representer;
 
 public class EscapedStringRepresenter extends Representer {
     public EscapedStringRepresenter() {
+        super(new DumperOptions());
         RepresentStringEx representStringEx = new RepresentStringEx();
         multiRepresenters.put(String.class, representStringEx);
         representers.put(String.class, representStringEx);


### PR DESCRIPTION
I replaced the deprecated methods in SnakeYAML 1.33 with the respective non-deprecated constructor calls. These are equivalent:
The deprecated non-arg constructor of Constructor https://bitbucket.org/snakeyaml/snakeyaml/src/snakeyaml-1.33/src/main/java/org/yaml/snakeyaml/constructor/Constructor.java calls https://bitbucket.org/snakeyaml/snakeyaml/src/7f5106920d7754ecab734725ba577083e55c7204/src/main/java/org/yaml/snakeyaml/constructor/SafeConstructor.java#lines-52, which uses a new empty LoaderOptions()

Similarly, SafeRepresenter https://bitbucket.org/snakeyaml/snakeyaml/src/7f5106920d7754ecab734725ba577083e55c7204/src/main/java/org/yaml/snakeyaml/representer/SafeRepresenter.java#lines-54 uses a new empty DumperOptions.