### PR TITLE
move AndrolidExceptions to the package brut.androlib.exceptions 

### DIFF
--- a/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
+++ b/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
@@ -17,9 +17,10 @@
 package brut.apktool;
 
 import brut.androlib.*;
-import brut.androlib.err.CantFindFrameworkResException;
-import brut.androlib.err.InFileNotFoundException;
-import brut.androlib.err.OutDirExistsException;
+import brut.androlib.exceptions.AndrolibException;
+import brut.androlib.exceptions.CantFindFrameworkResException;
+import brut.androlib.exceptions.InFileNotFoundException;
+import brut.androlib.exceptions.OutDirExistsException;
 import brut.androlib.options.BuildOptions;
 import brut.common.BrutException;
 import brut.directory.DirectoryException;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/Androlib.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/Androlib.java
@@ -16,6 +16,7 @@
  */
 package brut.androlib;
 
+import brut.androlib.exceptions.AndrolibException;
 import brut.androlib.meta.MetaInfo;
 import brut.androlib.meta.UsesFramework;
 import brut.androlib.options.BuildOptions;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
@@ -16,9 +16,10 @@
  */
 package brut.androlib;
 
-import brut.androlib.err.InFileNotFoundException;
-import brut.androlib.err.OutDirExistsException;
-import brut.androlib.err.UndefinedResObjectException;
+import brut.androlib.exceptions.AndrolibException;
+import brut.androlib.exceptions.InFileNotFoundException;
+import brut.androlib.exceptions.OutDirExistsException;
+import brut.androlib.exceptions.UndefinedResObjectException;
 import brut.androlib.meta.MetaInfo;
 import brut.androlib.meta.PackageInfo;
 import brut.androlib.meta.UsesFramework;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/exceptions/AXmlDecodingException.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/exceptions/AXmlDecodingException.java
@@ -14,9 +14,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package brut.androlib.err;
-
-import brut.androlib.AndrolibException;
+package brut.androlib.exceptions;
 
 public class AXmlDecodingException extends AndrolibException {
     public AXmlDecodingException(String message, Throwable cause) {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/exceptions/AndrolibException.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/exceptions/AndrolibException.java
@@ -14,12 +14,23 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package brut.androlib.err;
+package brut.androlib.exceptions;
 
-import brut.androlib.AndrolibException;
+import brut.common.BrutException;
 
-public class CantFind9PatchChunkException extends AndrolibException {
-	public CantFind9PatchChunkException(String message, Throwable cause) {
-		super(message, cause);
-	}
+public class AndrolibException extends BrutException {
+    public AndrolibException() {
+    }
+
+    public AndrolibException(String message) {
+        super(message);
+    }
+
+    public AndrolibException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public AndrolibException(Throwable cause) {
+        super(cause);
+    }
 }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/exceptions/CantFind9PatchChunkException.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/exceptions/CantFind9PatchChunkException.java
@@ -14,23 +14,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package brut.androlib.err;
+package brut.androlib.exceptions;
 
-import brut.androlib.AndrolibException;
-
-public class CantFindFrameworkResException extends AndrolibException {
-	public CantFindFrameworkResException(int id) {
-		mPkgId = id;
+public class CantFind9PatchChunkException extends AndrolibException {
+	public CantFind9PatchChunkException(String message, Throwable cause) {
+		super(message, cause);
 	}
-
-	public int getPkgId() {
-		return mPkgId;
-	}
-
-	@Override
-	public String getMessage() {
-		return String.format("Can't find framework resources for package of id: %d", this.getPkgId());
-	}
-
-	private final int mPkgId;
 }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/exceptions/CantFindFrameworkResException.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/exceptions/CantFindFrameworkResException.java
@@ -14,23 +14,21 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package brut.androlib;
+package brut.androlib.exceptions;
 
-import brut.common.BrutException;
+public class CantFindFrameworkResException extends AndrolibException {
+	public CantFindFrameworkResException(int id) {
+		mPkgId = id;
+	}
 
-public class AndrolibException extends BrutException {
-    public AndrolibException() {
-    }
+	public int getPkgId() {
+		return mPkgId;
+	}
 
-    public AndrolibException(String message) {
-        super(message);
-    }
+	@Override
+	public String getMessage() {
+		return String.format("Can't find framework resources for package of id: %d", this.getPkgId());
+	}
 
-    public AndrolibException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    public AndrolibException(Throwable cause) {
-        super(cause);
-    }
+	private final int mPkgId;
 }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/exceptions/InFileNotFoundException.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/exceptions/InFileNotFoundException.java
@@ -14,12 +14,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package brut.androlib.err;
+package brut.androlib.exceptions;
 
-import brut.androlib.AndrolibException;
-
-public class UndefinedResObjectException extends AndrolibException {
-	public UndefinedResObjectException(String message) {
-		super(message);
+public class InFileNotFoundException extends AndrolibException {
+	public InFileNotFoundException() {
 	}
 }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/exceptions/OutDirExistsException.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/exceptions/OutDirExistsException.java
@@ -14,12 +14,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package brut.androlib.err;
+package brut.androlib.exceptions;
 
-import brut.androlib.AndrolibException;
-
-public class RawXmlEncounteredException extends AndrolibException {
-    public RawXmlEncounteredException(String message, Throwable cause) {
-        super(message, cause);
-    }
+public class OutDirExistsException extends AndrolibException {
+	public OutDirExistsException() {
+	}
 }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/exceptions/RawXmlEncounteredException.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/exceptions/RawXmlEncounteredException.java
@@ -14,11 +14,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package brut.androlib.err;
+package brut.androlib.exceptions;
 
-import brut.androlib.AndrolibException;
-
-public class InFileNotFoundException extends AndrolibException {
-	public InFileNotFoundException() {
-	}
+public class RawXmlEncounteredException extends AndrolibException {
+    public RawXmlEncounteredException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/exceptions/UndefinedResObjectException.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/exceptions/UndefinedResObjectException.java
@@ -14,11 +14,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package brut.androlib.err;
+package brut.androlib.exceptions;
 
-import brut.androlib.AndrolibException;
-
-public class OutDirExistsException extends AndrolibException {
-	public OutDirExistsException() {
+public class UndefinedResObjectException extends AndrolibException {
+	public UndefinedResObjectException(String message) {
+		super(message);
 	}
 }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
@@ -16,9 +16,9 @@
  */
 package brut.androlib.res;
 
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 import brut.androlib.options.BuildOptions;
-import brut.androlib.err.CantFindFrameworkResException;
+import brut.androlib.exceptions.CantFindFrameworkResException;
 import brut.androlib.meta.MetaInfo;
 import brut.androlib.meta.PackageInfo;
 import brut.androlib.meta.VersionInfo;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResPackage.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResPackage.java
@@ -16,8 +16,8 @@
  */
 package brut.androlib.res.data;
 
-import brut.androlib.AndrolibException;
-import brut.androlib.err.UndefinedResObjectException;
+import brut.androlib.exceptions.AndrolibException;
+import brut.androlib.exceptions.UndefinedResObjectException;
 import brut.androlib.res.data.value.ResFileValue;
 import brut.androlib.res.data.value.ResValueFactory;
 import brut.androlib.res.xml.ResValuesXmlSerializable;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResResSpec.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResResSpec.java
@@ -16,8 +16,8 @@
  */
 package brut.androlib.res.data;
 
-import brut.androlib.AndrolibException;
-import brut.androlib.err.UndefinedResObjectException;
+import brut.androlib.exceptions.AndrolibException;
+import brut.androlib.exceptions.UndefinedResObjectException;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResResource.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResResource.java
@@ -16,7 +16,7 @@
  */
 package brut.androlib.res.data;
 
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 import brut.androlib.res.data.value.ResValue;
 
 public class ResResource {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResTable.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResTable.java
@@ -16,8 +16,8 @@
  */
 package brut.androlib.res.data;
 
-import brut.androlib.AndrolibException;
-import brut.androlib.err.UndefinedResObjectException;
+import brut.androlib.exceptions.AndrolibException;
+import brut.androlib.exceptions.UndefinedResObjectException;
 import brut.androlib.meta.VersionInfo;
 import brut.androlib.res.AndrolibResources;
 import brut.androlib.res.data.value.ResValue;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResType.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResType.java
@@ -16,8 +16,8 @@
  */
 package brut.androlib.res.data;
 
-import brut.androlib.AndrolibException;
-import brut.androlib.err.UndefinedResObjectException;
+import brut.androlib.exceptions.AndrolibException;
+import brut.androlib.exceptions.UndefinedResObjectException;
 import java.util.*;
 
 public class ResType {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResTypeSpec.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResTypeSpec.java
@@ -16,8 +16,8 @@
  */
 package brut.androlib.res.data;
 
-import brut.androlib.AndrolibException;
-import brut.androlib.err.UndefinedResObjectException;
+import brut.androlib.exceptions.AndrolibException;
+import brut.androlib.exceptions.UndefinedResObjectException;
 import java.util.*;
 
 public final class ResTypeSpec {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResArrayValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResArrayValue.java
@@ -16,7 +16,7 @@
  */
 package brut.androlib.res.data.value;
 
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 import brut.androlib.res.data.ResResource;
 import brut.androlib.res.xml.ResValuesXmlSerializable;
 import brut.util.Duo;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResAttr.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResAttr.java
@@ -16,7 +16,7 @@
  */
 package brut.androlib.res.data.value;
 
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 import brut.androlib.res.data.ResPackage;
 import brut.androlib.res.data.ResResource;
 import brut.androlib.res.xml.ResValuesXmlSerializable;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResBagValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResBagValue.java
@@ -16,7 +16,7 @@
  */
 package brut.androlib.res.data.value;
 
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 import brut.androlib.res.data.ResResource;
 import brut.androlib.res.xml.ResValuesXmlSerializable;
 import brut.util.Duo;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResDimenValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResDimenValue.java
@@ -17,7 +17,7 @@
 package brut.androlib.res.data.value;
 
 import android.util.TypedValue;
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 
 public class ResDimenValue extends ResIntValue {
     public ResDimenValue(int value, String rawValue) {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResEmptyValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResEmptyValue.java
@@ -16,7 +16,7 @@
  */
 package brut.androlib.res.data.value;
 
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 
 public class ResEmptyValue extends ResScalarValue {
     protected final int mValue;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResEnumAttr.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResEnumAttr.java
@@ -16,7 +16,7 @@
  */
 package brut.androlib.res.data.value;
 
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 import brut.androlib.res.data.ResResSpec;
 import brut.androlib.res.data.ResResource;
 import brut.util.Duo;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResFileValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResFileValue.java
@@ -16,7 +16,7 @@
  */
 package brut.androlib.res.data.value;
 
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 
 public class ResFileValue extends ResIntBasedValue {
     private final String mPath;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResFlagsAttr.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResFlagsAttr.java
@@ -16,7 +16,7 @@
  */
 package brut.androlib.res.data.value;
 
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 import brut.androlib.res.data.ResResource;
 import brut.util.Duo;
 import org.xmlpull.v1.XmlSerializer;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResFractionValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResFractionValue.java
@@ -17,7 +17,7 @@
 package brut.androlib.res.data.value;
 
 import android.util.TypedValue;
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 
 public class ResFractionValue extends ResIntValue {
     public ResFractionValue(int value, String rawValue) {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResIntValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResIntValue.java
@@ -17,7 +17,7 @@
 package brut.androlib.res.data.value;
 
 import android.util.TypedValue;
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 
 public class ResIntValue extends ResScalarValue {
     protected final int mValue;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResPluralsValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResPluralsValue.java
@@ -16,7 +16,7 @@
  */
 package brut.androlib.res.data.value;
 
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 import brut.androlib.res.data.ResResource;
 import brut.androlib.res.xml.ResValuesXmlSerializable;
 import brut.androlib.res.xml.ResXmlEncoders;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResReferenceValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResReferenceValue.java
@@ -16,8 +16,8 @@
  */
 package brut.androlib.res.data.value;
 
-import brut.androlib.AndrolibException;
-import brut.androlib.err.UndefinedResObjectException;
+import brut.androlib.exceptions.AndrolibException;
+import brut.androlib.exceptions.UndefinedResObjectException;
 import brut.androlib.res.data.ResPackage;
 import brut.androlib.res.data.ResResSpec;
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResScalarValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResScalarValue.java
@@ -16,7 +16,7 @@
  */
 package brut.androlib.res.data.value;
 
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 import brut.androlib.res.data.ResResource;
 import brut.androlib.res.xml.ResValuesXmlSerializable;
 import brut.androlib.res.xml.ResXmlEncodable;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResStringValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResStringValue.java
@@ -16,7 +16,7 @@
  */
 package brut.androlib.res.data.value;
 
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 import brut.androlib.res.data.ResResource;
 import brut.androlib.res.xml.ResXmlEncoders;
 import org.xmlpull.v1.XmlSerializer;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResStyleValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResStyleValue.java
@@ -16,7 +16,7 @@
  */
 package brut.androlib.res.data.value;
 
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 import brut.androlib.res.data.ResResSpec;
 import brut.androlib.res.data.ResResource;
 import brut.androlib.res.xml.ResValuesXmlSerializable;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResValueFactory.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResValueFactory.java
@@ -17,7 +17,7 @@
 package brut.androlib.res.data.value;
 
 import android.util.TypedValue;
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 import brut.androlib.res.data.ResPackage;
 import brut.androlib.res.data.ResTypeSpec;
 import brut.util.Duo;
@@ -107,7 +107,7 @@ public class ResValueFactory {
         if (ResTypeSpec.RES_TYPE_NAME_ATTR.equals(resTypeName)) {
             return new ResAttr(parentVal, 0, null, null, null);
         }
-        
+
         if (resTypeName.startsWith(ResTypeSpec.RES_TYPE_NAME_STYLES)) {
             return new ResStyleValue(parentVal, items, this);
         }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
@@ -17,7 +17,7 @@
 package brut.androlib.res.decoder;
 
 import android.util.TypedValue;
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 import brut.androlib.res.data.*;
 import brut.androlib.res.data.value.*;
 import brut.util.Duo;
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AXmlResourceParser.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AXmlResourceParser.java
@@ -18,7 +18,7 @@ package brut.androlib.res.decoder;
 
 import android.content.res.XmlResourceParser;
 import android.util.TypedValue;
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 import brut.androlib.res.data.ResID;
 import brut.androlib.res.xml.ResXmlEncoders;
 import brut.util.ExtDataInput;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/Res9patchStreamDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/Res9patchStreamDecoder.java
@@ -16,8 +16,8 @@
  */
 package brut.androlib.res.decoder;
 
-import brut.androlib.AndrolibException;
-import brut.androlib.err.CantFind9PatchChunkException;
+import brut.androlib.exceptions.AndrolibException;
+import brut.androlib.exceptions.CantFind9PatchChunkException;
 import brut.util.ExtDataInput;
 import org.apache.commons.io.IOUtils;
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResAttrDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResAttrDecoder.java
@@ -16,8 +16,8 @@
  */
 package brut.androlib.res.decoder;
 
-import brut.androlib.AndrolibException;
-import brut.androlib.err.UndefinedResObjectException;
+import brut.androlib.exceptions.AndrolibException;
+import brut.androlib.exceptions.UndefinedResObjectException;
 import brut.androlib.res.data.ResID;
 import brut.androlib.res.data.ResPackage;
 import brut.androlib.res.data.ResResSpec;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResFileDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResFileDecoder.java
@@ -16,9 +16,9 @@
  */
 package brut.androlib.res.decoder;
 
-import brut.androlib.AndrolibException;
-import brut.androlib.err.CantFind9PatchChunkException;
-import brut.androlib.err.RawXmlEncounteredException;
+import brut.androlib.exceptions.AndrolibException;
+import brut.androlib.exceptions.CantFind9PatchChunkException;
+import brut.androlib.exceptions.RawXmlEncounteredException;
 import brut.androlib.res.data.ResResource;
 import brut.androlib.res.data.value.ResBoolValue;
 import brut.androlib.res.data.value.ResFileValue;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResRawStreamDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResRawStreamDecoder.java
@@ -16,7 +16,7 @@
  */
 package brut.androlib.res.decoder;
 
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResStreamDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResStreamDecoder.java
@@ -16,7 +16,7 @@
  */
 package brut.androlib.res.decoder;
 
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 import java.io.InputStream;
 import java.io.OutputStream;
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResStreamDecoderContainer.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResStreamDecoderContainer.java
@@ -16,7 +16,7 @@
  */
 package brut.androlib.res.decoder;
 
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.HashMap;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/XmlPullStreamDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/XmlPullStreamDecoder.java
@@ -16,9 +16,9 @@
  */
 package brut.androlib.res.decoder;
 
-import brut.androlib.AndrolibException;
-import brut.androlib.err.AXmlDecodingException;
-import brut.androlib.err.RawXmlEncounteredException;
+import brut.androlib.exceptions.AndrolibException;
+import brut.androlib.exceptions.AXmlDecodingException;
+import brut.androlib.exceptions.RawXmlEncounteredException;
 import brut.androlib.res.data.ResTable;
 import brut.androlib.res.util.ExtXmlSerializer;
 import org.xmlpull.v1.XmlPullParser;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResValuesXmlSerializable.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResValuesXmlSerializable.java
@@ -16,7 +16,7 @@
  */
 package brut.androlib.res.xml;
 
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 import brut.androlib.res.data.ResResource;
 import org.xmlpull.v1.XmlSerializer;
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResXmlEncodable.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResXmlEncodable.java
@@ -16,7 +16,7 @@
  */
 package brut.androlib.res.xml;
 
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 
 public interface ResXmlEncodable {
     String encodeAsResXmlAttr() throws AndrolibException;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResXmlPatcher.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResXmlPatcher.java
@@ -16,7 +16,7 @@
  */
 package brut.androlib.res.xml;
 
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 import org.w3c.dom.*;
 import org.xml.sax.SAXException;
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/src/SmaliBuilder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/src/SmaliBuilder.java
@@ -16,7 +16,7 @@
  */
 package brut.androlib.src;
 
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 import brut.androlib.mod.SmaliMod;
 import brut.directory.DirectoryException;
 import brut.directory.ExtFile;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/src/SmaliDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/src/SmaliDecoder.java
@@ -16,7 +16,7 @@
  */
 package brut.androlib.src;
 
-import brut.androlib.AndrolibException;
+import brut.androlib.exceptions.AndrolibException;
 import com.android.tools.smali.baksmali.Baksmali;
 import com.android.tools.smali.baksmali.BaksmaliOptions;
 import com.android.tools.smali.dexlib2.DexFileFactory;

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/TestUtils.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/TestUtils.java
@@ -16,6 +16,7 @@
  */
 package brut.androlib;
 
+import brut.androlib.exceptions.AndrolibException;
 import brut.androlib.options.BuildOptions;
 import brut.androlib.res.AndrolibResources;
 import brut.common.BrutException;

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/SharedLibraryTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/SharedLibraryTest.java
@@ -17,6 +17,7 @@
 package brut.androlib.aapt1;
 
 import brut.androlib.*;
+import brut.androlib.exceptions.AndrolibException;
 import brut.androlib.options.BuildOptions;
 import brut.directory.ExtFile;
 import brut.common.BrutException;

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/NonStandardPkgIdTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/NonStandardPkgIdTest.java
@@ -17,6 +17,7 @@
 package brut.androlib.aapt2;
 
 import brut.androlib.*;
+import brut.androlib.exceptions.AndrolibException;
 import brut.androlib.options.BuildOptions;
 import brut.androlib.res.data.ResTable;
 import brut.common.BrutException;

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/DecodeKotlinCoroutinesTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/DecodeKotlinCoroutinesTest.java
@@ -17,6 +17,7 @@
 package brut.androlib.decode;
 
 import brut.androlib.*;
+import brut.androlib.exceptions.AndrolibException;
 import brut.common.BrutException;
 import brut.directory.DirectoryException;
 import brut.directory.ExtFile;

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/DuplicateDexTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/DuplicateDexTest.java
@@ -17,6 +17,7 @@
 package brut.androlib.decode;
 
 import brut.androlib.*;
+import brut.androlib.exceptions.AndrolibException;
 import brut.androlib.options.BuildOptions;
 import brut.common.BrutException;
 import brut.directory.ExtFile;


### PR DESCRIPTION
1. move AndrolidExceptions to the package brut.androlib.err
2. rename brut.androlib.err to brut.androlib.exceptions

