### PR TITLE
refactor: put gradle wrapper on its own workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
-      - uses: gradle/wrapper-validation-action@v1.0.6
       - name: Build and test
         uses: gradle/gradle-build-action@v2.4.2
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,22 @@
+name: Gradle Validate
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - 'gradle/wrapper/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-gradle-wrapper:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 17
+      - uses: gradle/wrapper-validation-action@v1.0.6


### PR DESCRIPTION
This is failing quite often when fired off 20~ at once. It doesn't need to be like that. Isolate to its own workflow.