### PR TITLE
Use legacy method to decode XML attribute names [#2981]

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AXmlResourceParser.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AXmlResourceParser.java
@@ -342,7 +342,7 @@ public class AXmlResourceParser implements XmlResourceParser {
         // retrieve the exact attribute name by its id.
         if (value == null || value.length() == 0) {
             try {
-                value = mAttrDecoder.decodeManifestAttr(getAttributeNameResource(index));
+                value = mAttrDecoder.decodeManifestAttrLegacy(getAttributeNameResource(index));
                 if (value == null) {
                     value = "";
                 }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResAttrDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResAttrDecoder.java
@@ -73,6 +73,20 @@ public class ResAttrDecoder {
         return null;
     }
 
+    public String decodeManifestAttrLegacy(int attrResId)
+        throws AndrolibException {
+
+        if (attrResId != 0) {
+            ResResSpec resResSpec = getCurrentPackage().getResTable().getResSpec(attrResId);
+
+            if (resResSpec != null) {
+                return resResSpec.getName();
+            }
+        }
+
+        return null;
+    }
+
     public ResPackage getCurrentPackage() throws AndrolibException {
         if (mCurrentPackage == null) {
             throw new AndrolibException("Current package not set");


### PR DESCRIPTION
Hello,
I noticed that APKTool was [no longer able to decode the attribute names in XML files](https://github.com/iBotPeaches/Apktool/issues/2981) (at least in my case).
[Someone found out](https://github.com/iBotPeaches/Apktool/issues/2981#issuecomment-1532811652) that the regression was introduced by commit [3fff2f1](https://github.com/iBotPeaches/Apktool/commit/3fff2f128e73de02cc5191ef9c9d7bbc940832a5).

I re-added the legacy `decodeManifestAttr` method besides the new one. The old one uses the `ResTable` which works differently (obviously) than getting a resource via the `ResPackage` directly. It did not work when I tried to use one method (neither one) for all cases. The old method is only called in the `getAttributeName` function. Now it passes all unit tests and does work for my apk that I needed.

This is meant to be at most a temporary fix or maybe you won't merge it at all. But I hope this might help you investigate the regression. I didn't dive too deep into your code, so there will be better solution.

So now my apk decompiles correctly, but I still get a few errors on attributes with the "app" namespace when I rebuild, like this:
`W: WhatsApp/res/drawable/mtrl_switch_thumb.xml:6: error: attribute state_with_icon (aka com.whatsapp:state_with_icon) not found.`
Line in the XML:
`<item android:id="@id/with_icon" android:drawable="@drawable/mtrl_switch_thumb_checked" app:state_with_icon="true" />`
I don't know whether this is related to this issue or it is a different story, but maybe you can help me fix this.

Thank you!