### PR TITLE
Refactor ARSCDecoder

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StringBlock.java
@@ -43,11 +43,11 @@ public class StringBlock {
         int chunkSize = reader.readInt();
 
         // ResStringPool_header
-        int stringCount = reader.readInt();
-        int styleCount = reader.readInt();
-        int flags = reader.readInt();
-        int stringsOffset = reader.readInt();
-        int stylesOffset = reader.readInt();
+        int stringCount = reader.readInt(); // stringCount (uint32_t)
+        int styleCount = reader.readInt(); // styleCount (uint32_t)
+        int flags = reader.readInt(); // flags (uint32_t)
+        int stringsOffset = reader.readInt(); // stringsStart (uint32_t)
+        int stylesOffset = reader.readInt(); // stylesOffset (uint32_t)
 
         StringBlock block = new StringBlock();
         block.m_isUTF8 = (flags & UTF8_FLAG) != 0;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/arsc/ARSCHeader.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/arsc/ARSCHeader.java
@@ -38,14 +38,18 @@ public class ARSCHeader {
     }
 
     public static ARSCHeader read(ExtDataInput in, CountingInputStream countIn) throws IOException {
+        // ResChunk_header
         short type;
         int start = countIn.getCount();
         try {
-            type = in.readShort();
+            type = in.readShort(); // type (uint16_t)
         } catch (EOFException ex) {
             return new ARSCHeader(TYPE_NONE, 0, 0, countIn.getCount());
         }
-        return new ARSCHeader(type, in.readShort(), in.readInt(), start);
+
+        int headerSize = in.readShort(); // headerSize (uint16_t)
+        int chunkSize = in.readInt(); // chunkSize (uint32_t)
+        return new ARSCHeader(type, headerSize, chunkSize, start);
     }
 
     public final static short TYPE_NONE = -1;


### PR DESCRIPTION
- [ ]  Label each property with data size/name from upstream AOSP [ResourceTypes.h](https://github.com/iBotPeaches/platform_frameworks_base/blob/master/libs/androidfw/include/androidfw/ResourceTypes.h#L425)
- [ ] Port each chunk reading into infinite loop parser with smart detection to detect reading out of bounds of chunk
- [ ] Align name of functions to make it clear what reads/parses from the incoming data stream
- [ ] Rework chunk parsers that abuse responsibility intended for loop parser