### PR TITLE
fix: skip parsing if chunk end is reached within table chunk

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
@@ -305,6 +305,16 @@ public class ARSCDecoder {
             }
             mMissingResSpecMap.put(i, false);
             mResId = (mResId & 0xffff0000) | i;
+
+            // As seen in some recent APKs - there are more entries reported than can fit in the chunk.
+            if (mCountIn.getCount() == mHeader.endPosition) {
+                int remainingEntries = entryCount - i;
+                LOGGER.warning(String.format("End of chunk hit. Skipping remaining entries (%d) in type: %s",
+                    remainingEntries, mTypeSpec.getName())
+                );
+                break;
+            }
+
             readEntry(readEntryData());
         }
 


### PR DESCRIPTION
fixes: #3036 

This cannot be a valid application, but the `entriesCount` seems to be lying. We exceed the chunk size before we are done reading the items. This makes sense in a way because ending the chunk reading when limit is fixed - does correct parsing

However, I am confused how tools like arscblamer, android studio, etc are reading all assets with no skipping of chunks. So perhaps this data is somewhere else, but I'm not sure where. The spec states

https://github.com/aosp-mirror/platform_frameworks_base/blob/main/libs/androidfw/include/androidfw/ResourceTypes.h#L1228
```
    // Number of uint32_t entry indices that follow.
    uint32_t entryCount;

    // Offset from header where ResTable_entry data starts.
    uint32_t entriesStart;
```

I've confirmed:

 * We are starting reading the entries at correct offset
 * We properly read the count
 * Reading past the chunk limit does crash quite quick