### PR TITLE
fix: don't default to --force on upgrade

### DIFF
--- a/blog/2016/2016-10-18-release221.mdx
+++ b/blog/2016/2016-10-18-release221.mdx
@@ -9,7 +9,7 @@ tags: [release]
 
 This release contains an updated internal framework file.
 
-- `apktool empty-framework-dir --force` to remove the old file.
+- `apktool empty-framework-dir` to remove the old file.
 
 :::
 

--- a/blog/2017/2017-01-23-release222.mdx
+++ b/blog/2017/2017-01-23-release222.mdx
@@ -9,7 +9,7 @@ tags: [release]
 
 This release contains an updated internal framework file.
 
-- `apktool empty-framework-dir --force` to remove the old file.
+- `apktool empty-framework-dir` to remove the old file.
 
 :::
 

--- a/blog/2017/2017-06-13-release223.mdx
+++ b/blog/2017/2017-06-13-release223.mdx
@@ -9,7 +9,7 @@ tags: [release]
 
 This release contains an updated internal framework file.
 
-- `apktool empty-framework-dir --force` to remove the old file.
+- `apktool empty-framework-dir` to remove the old file.
 
 :::
 

--- a/blog/2017/2017-07-29-release224.mdx
+++ b/blog/2017/2017-07-29-release224.mdx
@@ -9,7 +9,7 @@ tags: [release]
 
 This release contains an updated internal framework file.
 
-- `apktool empty-framework-dir --force` to remove the old file.
+- `apktool empty-framework-dir` to remove the old file.
 
 :::
 

--- a/blog/2017/2017-09-21-release230.mdx
+++ b/blog/2017/2017-09-21-release230.mdx
@@ -9,7 +9,7 @@ tags: [release]
 
 This release contains an updated internal framework file.
 
-- `apktool empty-framework-dir --force` to remove the old file.
+- `apktool empty-framework-dir` to remove the old file.
 
 :::
 

--- a/blog/2017/2017-12-26-release231.mdx
+++ b/blog/2017/2017-12-26-release231.mdx
@@ -9,7 +9,7 @@ tags: [release]
 
 This release contains an updated internal framework file.
 
-- `apktool empty-framework-dir --force` to remove the old file.
+- `apktool empty-framework-dir` to remove the old file.
 
 :::
 

--- a/blog/2018/2018-04-07-release232.mdx
+++ b/blog/2018/2018-04-07-release232.mdx
@@ -9,7 +9,7 @@ tags: [release]
 
 This release contains an updated internal framework file.
 
-- `apktool empty-framework-dir --force` to remove the old file.
+- `apktool empty-framework-dir` to remove the old file.
 
 :::
 

--- a/blog/2018/2018-09-05-release234.mdx
+++ b/blog/2018/2018-09-05-release234.mdx
@@ -9,7 +9,7 @@ tags: [release]
 
 This release contains an updated internal framework file.
 
-- `apktool empty-framework-dir --force` to remove the old file.
+- `apktool empty-framework-dir` to remove the old file.
 
 :::
 

--- a/blog/2019/2019-11-19-release241.mdx
+++ b/blog/2019/2019-11-19-release241.mdx
@@ -9,7 +9,7 @@ tags: [release]
 
 This release contains an updated internal framework file.
 
-- `apktool empty-framework-dir --force` to remove the old file.
+- `apktool empty-framework-dir` to remove the old file.
 
 :::
 

--- a/blog/2020/2020-12-02-release250.mdx
+++ b/blog/2020/2020-12-02-release250.mdx
@@ -9,7 +9,7 @@ tags: [release]
 
 This release contains an updated internal framework file.
 
-- `apktool empty-framework-dir --force` to remove the old file.
+- `apktool empty-framework-dir` to remove the old file.
 
 :::
 

--- a/blog/2021/2021-09-02-release260.mdx
+++ b/blog/2021/2021-09-02-release260.mdx
@@ -9,7 +9,7 @@ tags: [release]
 
 This release contains an updated internal framework file.
 
-- `apktool empty-framework-dir --force` to remove the old file.
+- `apktool empty-framework-dir` to remove the old file.
 
 :::
 

--- a/blog/2022/2022-11-24-release270.mdx
+++ b/blog/2022/2022-11-24-release270.mdx
@@ -9,7 +9,7 @@ tags: [release]
 
 This release contains an updated internal framework file.
 
-- `apktool empty-framework-dir --force` to remove the old file.
+- `apktool empty-framework-dir` to remove the old file.
 
 :::
 


### PR DESCRIPTION
We should let the user be warned they have more frameworks than the default and opt into forced themselves. Just in case there is a situation where folks are caught off-guard by the upgrade guide purging all framework files.