### PR TITLE
fix: skip files if cleaned to empty filename

### DIFF
--- a/brut.j.dir/src/main/java/brut/directory/DirUtil.java
+++ b/brut.j.dir/src/main/java/brut/directory/DirUtil.java
@@ -89,10 +89,12 @@ public class DirUtil {
                 // Skip copies of directories/files not found.
             } else {
                 String cleanedFilename = BrutIO.sanitizeUnknownFile(out, fileName);
-                File outFile = new File(out, cleanedFilename);
-                //noinspection ResultOfMethodCallIgnored
-                outFile.getParentFile().mkdirs();
-                BrutIO.copyAndClose(in.getFileInput(fileName), Files.newOutputStream(outFile.toPath()));
+                if (! cleanedFilename.isEmpty()) {
+                    File outFile = new File(out, cleanedFilename);
+                    //noinspection ResultOfMethodCallIgnored
+                    outFile.getParentFile().mkdirs();
+                    BrutIO.copyAndClose(in.getFileInput(fileName), Files.newOutputStream(outFile.toPath()));
+                }
             }
         } catch (RootUnknownFileException | InvalidUnknownFileException | TraversalUnknownFileException exception) {
             LOGGER.warning(String.format("Skipping file %s (%s)", fileName, exception.getMessage()));


### PR DESCRIPTION
fixes: #3165 