### PR TITLE
fix: opt out of stricter java rules for zip64 and dot entries

### DIFF
--- a/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
+++ b/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
@@ -42,6 +42,12 @@ public class Main {
         // headless
         System.setProperty("java.awt.headless", "true");
 
+        // Ignore stricter validation on zip files from java 11 onwards as this is a protection technique
+        // that applications use to thwart disassembly tools. We have protections in place for directory traversal
+        // and handling of bogus data in the zip header, so we can ignore this.
+        System.setProperty("jdk.nio.zipfs.allowDotZipEntry", "true");
+        System.setProperty("jdk.util.zip.disableZip64ExtraFieldValidation", "true");
+
         // set verbosity default
         Verbosity verbosity = Verbosity.NORMAL;
 

--- a/build.gradle
+++ b/build.gradle
@@ -142,6 +142,10 @@ subprojects {
     apply plugin: 'java'
 
     test {
+        // https://github.com/iBotPeaches/Apktool/issues/3174
+        systemProperty 'jdk.nio.zipfs.allowDotZipEntry', 'true'
+        systemProperty 'jdk.util.zip.disableZip64ExtraFieldValidation', 'true'
+
         testLogging {
             exceptionFormat = 'full'
         }


### PR DESCRIPTION
fixes: #3174 
fixes: #3170 

* A restriction added to Java and then back-ported to LTS 11 and 17 - https://github.com/openjdk/jdk/commit/fff7e1ad00be07810bf948b8a6f94e83c435fa1f

![Screenshot 2023-07-19 at 4 31 42 PM](https://github.com/iBotPeaches/Apktool/assets/611784/0a64aa1f-4d44-4ea0-8649-092c21b3f38e)

![Screenshot 2023-07-19 at 4 36 12 PM](https://github.com/iBotPeaches/Apktool/assets/611784/754a9d9d-328a-4059-a978-763eba3cfa3b)

https://www.oracle.com/java/technologies/javase/11-0-20-relnotes.html