### PR TITLE
Allows run app from gradle for debugging purposes

### DIFF
--- a/brut.apktool/apktool-cli/build.gradle
+++ b/brut.apktool/apktool-cli/build.gradle
@@ -42,17 +42,24 @@ application {
     mainClass = 'brut.apktool.Main'
 }
 
+tasks.named('run') {
+    // run from root directory
+    // otherwise run from brut.apktool/apktool-cli
+    workingDir = file(System.getProperty('user.dir'))
+}
+
 jar {
     manifest {
         attributes 'Main-Class': 'brut.apktool.Main'
     }
 }
 
-task cleanOutputDirectory(type: Delete) {
+tasks.register('cleanOutputDirectory', Delete) {
     delete fileTree(dir: jar.getDestinationDirectory().getAsFile(), exclude: "apktool-cli-all.jar")
 }
 
-task proguard(type: ProGuardTask, dependsOn: shadowJar) {
+tasks.register('proguard', ProGuardTask) {
+    dependsOn shadowJar
     injars shadowJar.getArchiveFile()
 
     // Java 9 and prior uses merged package for runtime, later uses split jmod files.

--- a/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
+++ b/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
@@ -177,7 +177,8 @@ public class Main {
             outDir = new File(outName);
         }
 
-        ApkDecoder decoder = new ApkDecoder(config, new ExtFile(apkName));
+        ExtFile apkFile = new ExtFile(apkName);
+        ApkDecoder decoder = new ApkDecoder(config, apkFile);
 
         try {
             decoder.decode(outDir);
@@ -189,7 +190,7 @@ public class Main {
                             + "already exists. Use -f switch if you want to overwrite it.");
             System.exit(1);
         } catch (InFileNotFoundException ex) {
-            System.err.println("Input file (" + apkName + ") " + "was not found or was not readable.");
+            System.err.println("Input file (" + apkFile.getAbsolutePath() + ") " + "was not found or was not readable.");
             System.exit(1);
         } catch (CantFindFrameworkResException ex) {
             System.err


### PR DESCRIPTION
In the Idea add gradle execution configuration.

Using:

in the `.gitignore` exists bin/ and out/ directory. Place apk in the bin/ directory and decoding to the out/ directory.
   
Configuration for decode use Run: `run --args="b -o bin/rebuild.apk out"`

Configuration for build use Run: `run --args="b -o bin/rebuild.apk out"`

In the Main class add printing apk full path if dont find it. 
