### PR TITLE
fix: add missing hasResources check

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
@@ -135,7 +135,7 @@ public class ApkDecoder {
 
             // In case we have no resources. We should store the minSdk we pulled from the source opcode api level
             ApkInfo apkInfo = resourcesDecoder.getApkInfo();
-            if (mMinSdkVersion > 0) {
+            if (! resourcesDecoder.hasResources() && mMinSdkVersion > 0) {
                 apkInfo.setSdkInfoField("minSdkVersion", Integer.toString(mMinSdkVersion));
             }
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/ResourcesDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/ResourcesDecoder.java
@@ -65,7 +65,7 @@ public class ResourcesDecoder {
         mResTable = new ResTable(mConfig, mApkInfo);
     }
 
-    private boolean hasManifest() throws AndrolibException {
+    public boolean hasManifest() throws AndrolibException {
         try {
             return mApkFile.getDirectory().containsFile("AndroidManifest.xml");
         } catch (DirectoryException ex) {
@@ -73,7 +73,7 @@ public class ResourcesDecoder {
         }
     }
 
-    private boolean hasResources() throws AndrolibException {
+    public boolean hasResources() throws AndrolibException {
         try {
             return mApkFile.getDirectory().containsFile("resources.arsc");
         } catch (DirectoryException ex) {


### PR DESCRIPTION
There's a missing check for hasResources in ApkDecoder, which causes minSdkVersion to be force-replaced for APKs also, not just for JARs, which often causes an inconsistency with the original APK.
As such, the hasResources of ResourcesDecoder must be public (ideally "package-private", but ResourcesDecoder is in "res" sub-package so that is not viable).
Also made hasManifest public for consistency's sake to avoid confusion and open it for possible usage in ApkDecoder in the future.