### PR TITLE
fix: revert change that broke loading framework packages

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkBuilder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkBuilder.java
@@ -170,7 +170,6 @@ public class ApkBuilder {
             File[] dexFiles = appDir.listFiles();
             if (dexFiles != null) {
                 for (File dex : dexFiles) {
-
                     // skip classes.dex because we have handled it in buildSources()
                     if (dex.getName().endsWith(".dex") && ! dex.getName().equalsIgnoreCase("classes.dex")) {
                         buildSourcesRaw(appDir, dex.getName());

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/ResourcesDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/ResourcesDecoder.java
@@ -35,9 +35,7 @@ import org.xmlpull.v1.XmlSerializer;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.logging.Logger;
 
 public class ResourcesDecoder {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/src/SmaliBuilder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/src/SmaliBuilder.java
@@ -24,6 +24,7 @@ import org.antlr.runtime.RecognitionException;
 import com.android.tools.smali.dexlib2.Opcodes;
 import com.android.tools.smali.dexlib2.writer.builder.DexBuilder;
 import com.android.tools.smali.dexlib2.writer.io.FileDataStore;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;

--- a/brut.j.util/src/main/java/brut/util/Duo.java
+++ b/brut.j.util/src/main/java/brut/util/Duo.java
@@ -27,6 +27,7 @@ public class Duo<T1, T2> {
         this.m2 = t2;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public boolean equals(Object obj) {
         if (obj == null) {


### PR DESCRIPTION
The changes made in ResAttrDecoder.java were reverted as they break loading framework packages during decompilation.
This fixes #3181.

Added minor redundancy cleaning as a bonus.