### PR TITLE
Prevent loading from resource pool if type is not a resolveable resource

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AXmlResourceParser.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AXmlResourceParser.java
@@ -387,7 +387,14 @@ public class AXmlResourceParser implements XmlResourceParser {
         if (mAttrDecoder != null) {
             try {
                 String stringBlockValue = valueRaw == -1 ? null : ResXmlEncoders.escapeXmlChars(mStringBlock.getString(valueRaw));
-                String resourceMapValue = mAttrDecoder.decodeFromResourceId(valueData);
+                String resourceMapValue = null;
+
+                // Ensure we only track down obfuscated values for reference/attribute type values. Otherwise we might
+                // spam lookups against resource table for invalid ids.
+                if (valueType == TypedValue.TYPE_REFERENCE || valueType == TypedValue.TYPE_DYNAMIC_REFERENCE ||
+                    valueType == TypedValue.TYPE_ATTRIBUTE || valueType == TypedValue.TYPE_DYNAMIC_ATTRIBUTE) {
+                    resourceMapValue = mAttrDecoder.decodeFromResourceId(valueData);
+                }
                 String value = stringBlockValue;
 
                 if (stringBlockValue != null && resourceMapValue != null) {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResAttrDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResAttrDecoder.java
@@ -46,10 +46,8 @@ public class ResAttrDecoder {
         throws AndrolibException {
 
         if (attrResId != 0) {
-            ResID resId = new ResID(attrResId);
-
             try {
-                ResResSpec resResSpec = mResTable.getResSpec(resId);
+                ResResSpec resResSpec = mResTable.getResSpec(attrResId);
                 if (resResSpec != null) {
                     return resResSpec.getName();
                 }


### PR DESCRIPTION
* Superseeds: https://github.com/iBotPeaches/Apktool/pull/3185
* Fixes: #3181

---

In testing I noticed that we were attempting to resolve any value from the resource pool and string pool. This doesn't makes sense all the time for the resource pool for all types. For example, if we got a type float (`0x04`) we'd cast it and shift it to resourceId from the local package. It might/might-not find a resource - thankfully it was always wrong so it didn't win out. It was however inefficient.