### PR TITLE
style: normalize command descs and redundancy

### DIFF
--- a/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
+++ b/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
@@ -307,12 +307,12 @@ public class Main {
         // create options
         Option versionOption = Option.builder("version")
                 .longOpt("version")
-                .desc("prints the version then exits")
+                .desc("Print the version.")
                 .build();
 
         Option advanceOption = Option.builder("advance")
                 .longOpt("advanced")
-                .desc("prints advance information.")
+                .desc("Print advanced information.")
                 .build();
 
         Option noSrcOption = Option.builder("s")
@@ -347,7 +347,7 @@ public class Main {
 
         Option analysisOption = Option.builder("m")
                 .longOpt("match-original")
-                .desc("Keeps files to closest to original as possible. Prevents rebuild.")
+                .desc("Keep files to closest to original as possible (prevents rebuild).")
                 .build();
 
         Option apiLevelOption = Option.builder("api")
@@ -359,17 +359,17 @@ public class Main {
 
         Option debugBuiOption = Option.builder("d")
                 .longOpt("debug")
-                .desc("Sets android:debuggable to \"true\" in the APK's compiled manifest")
+                .desc("Set android:debuggable to \"true\" in the APK's compiled manifest.")
                 .build();
 
         Option netSecConfOption = Option.builder("n")
-            .longOpt("net-sec-conf")
-            .desc("Adds a generic Network Security Configuration file in the output APK")
-            .build();
+                .longOpt("net-sec-conf")
+                .desc("Add a generic Network Security Configuration file in the output APK")
+                .build();
 
         Option noDbgOption = Option.builder("b")
                 .longOpt("no-debug-info")
-                .desc("don't write out debug info (.local, .param, .line, etc.)")
+                .desc("Do not write out debug info (.local, .param, .line, etc.)")
                 .build();
 
         Option forceDecOption = Option.builder("f")
@@ -379,21 +379,21 @@ public class Main {
 
         Option frameTagOption = Option.builder("t")
                 .longOpt("frame-tag")
-                .desc("Uses framework files tagged by <tag>.")
+                .desc("Use framework files tagged by <tag>.")
                 .hasArg(true)
                 .argName("tag")
                 .build();
 
         Option frameDirOption = Option.builder("p")
                 .longOpt("frame-path")
-                .desc("Uses framework files located in <dir>.")
+                .desc("Use framework files located in <dir>.")
                 .hasArg(true)
                 .argName("dir")
                 .build();
 
         Option frameIfDirOption = Option.builder("p")
                 .longOpt("frame-path")
-                .desc("Stores framework files into <dir>.")
+                .desc("Store framework files into <dir>.")
                 .hasArg(true)
                 .argName("dir")
                 .build();
@@ -415,17 +415,17 @@ public class Main {
                 .longOpt("aapt")
                 .hasArg(true)
                 .argName("loc")
-                .desc("Loads aapt from specified location.")
+                .desc("Load aapt from specified location.")
                 .build();
 
         Option aapt2Option = Option.builder()
                 .longOpt("use-aapt2")
-                .desc("Upgrades apktool to use experimental aapt2 binary.")
+                .desc("Use aapt2 binary instead of aapt1 during the build step.")
                 .build();
 
         Option originalOption = Option.builder("c")
                 .longOpt("copy-original")
-                .desc("Copies original AndroidManifest.xml and META-INF. See project page for more info.")
+                .desc("Copy original AndroidManifest.xml and META-INF. See project page for more info.")
                 .build();
 
         Option noCrunchOption = Option.builder("nc")
@@ -442,14 +442,14 @@ public class Main {
 
         Option outputBuiOption = Option.builder("o")
                 .longOpt("output")
-                .desc("The name of apk that gets written. Default is dist/name.apk")
+                .desc("The name of apk that gets written. (default: dist/name.apk)")
                 .hasArg(true)
                 .argName("dir")
                 .build();
 
         Option outputDecOption = Option.builder("o")
                 .longOpt("output")
-                .desc("The name of folder that gets written. Default is apk.out")
+                .desc("The name of folder that gets written. (default: apk.out)")
                 .hasArg(true)
                 .argName("dir")
                 .build();

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkBuilder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkBuilder.java
@@ -170,7 +170,6 @@ public class ApkBuilder {
             File[] dexFiles = appDir.listFiles();
             if (dexFiles != null) {
                 for (File dex : dexFiles) {
-
                     // skip classes.dex because we have handled it in buildSources()
                     if (dex.getName().endsWith(".dex") && ! dex.getName().equalsIgnoreCase("classes.dex")) {
                         buildSourcesRaw(appDir, dex.getName());

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/ResourcesDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/ResourcesDecoder.java
@@ -35,9 +35,7 @@ import org.xmlpull.v1.XmlSerializer;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.logging.Logger;
 
 public class ResourcesDecoder {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/src/SmaliBuilder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/src/SmaliBuilder.java
@@ -24,6 +24,7 @@ import org.antlr.runtime.RecognitionException;
 import com.android.tools.smali.dexlib2.Opcodes;
 import com.android.tools.smali.dexlib2.writer.builder.DexBuilder;
 import com.android.tools.smali.dexlib2.writer.io.FileDataStore;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;

--- a/brut.j.util/src/main/java/brut/util/Duo.java
+++ b/brut.j.util/src/main/java/brut/util/Duo.java
@@ -27,6 +27,7 @@ public class Duo<T1, T2> {
         this.m2 = t2;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public boolean equals(Object obj) {
         if (obj == null) {


### PR DESCRIPTION
No functional changes, the purpose is to make command descriptions grammatically consistent.
Also removed some redundancy for consistency inside their package.
Added @SuppressWarnings("unchecked") for Duo class to mark the unchecked behavior as intentional.