### PR TITLE
fix: crash when decompiling framework-res.apk with a tag (regression)

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/ResourcesDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/ResourcesDecoder.java
@@ -243,9 +243,6 @@ public class ResourcesDecoder {
                     break;
             }
             mResTable.initApkInfo(mApkInfo, outDir);
-            if (mConfig.frameworkTag != null) {
-                mApkInfo.usesFramework.tag = mConfig.frameworkTag;
-            }
         }
         return mResTable;
     }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResTable.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResTable.java
@@ -291,7 +291,7 @@ public class ResTable {
     }
 
     private boolean isFrameworkApk() {
-        for (ResPackage pkg : listMainPackages()) {
+        for (ResPackage pkg : mMainPackages) {
             if (pkg.getId() > 0 && pkg.getId() < 64) {
                 return true;
             }
@@ -301,9 +301,7 @@ public class ResTable {
 
     public void initApkInfo(ApkInfo apkInfo, File outDir) throws AndrolibException {
         apkInfo.isFrameworkApk = isFrameworkApk();
-        if (!listFramePackages().isEmpty()) {
-            apkInfo.usesFramework = getUsesFramework();
-        }
+        apkInfo.usesFramework = getUsesFramework();
         if (!mApkInfo.getSdkInfo().isEmpty()) {
             updateSdkInfoFromResources(outDir);
         }
@@ -312,18 +310,15 @@ public class ResTable {
     }
 
     private UsesFramework getUsesFramework() {
-        Set<ResPackage> pkgs = listFramePackages();
-
-        Integer[] ids = new Integer[pkgs.size()];
+        UsesFramework info = new UsesFramework();
+        Integer[] ids = new Integer[mFramePackages.size()];
         int i = 0;
-        for (ResPackage pkg : pkgs) {
+        for (ResPackage pkg : mFramePackages) {
             ids[i++] = pkg.getId();
         }
         Arrays.sort(ids);
-
-        UsesFramework info = new UsesFramework();
         info.ids = Arrays.asList(ids);
-
+        info.tag = mConfig.frameworkTag;
         return info;
     }
 


### PR DESCRIPTION
This fixes a regression since 2.8.0 that causes apktool to crash when decompiling framework-res.apk (which has no other framework dependencies):

```
$ java -jar apktool.jar d -f -t mytag framework-res.apk -o framework-res
I: Using Apktool 2.8.1-SNAPSHOT on framework-res.apk
I: Loading resource table...
I: Decoding AndroidManifest.xml with resources...
I: Regular manifest package...
I: Decoding file-resources...
I: Decoding values */* XMLs...
Exception in thread "main" java.lang.NullPointerException
        at brut.androlib.res.ResourcesDecoder.decodeResources(ResourcesDecoder.java:247)
        at brut.androlib.ApkDecoder.decode(ApkDecoder.java:98)
        at brut.apktool.Main.cmdDecode(Main.java:190)
        at brut.apktool.Main.main(Main.java:93)
```

This is caused by the fact that `mApkInfo.usesFramework` is `null` if there are no framework dependencies for a given APK (which is true for any base framework, i.e. framework-res.apk), and then doing `mApkInfo.usesFramework.tag = mConfig.frameworkTag;` in `ResourcesDecoder`, causing a `NullPointerException`.
How wasn't it caught during development? Perhaps due to the previous framework loading regression that recently got fixed, that loaded frameworks with arbitrary IDs, which caused `UsesFramework` to always be created because `ids` array was never empty, even when it should have been.
And so:
1) There is no good reason not to always create a UsesFramework object, regardless of content.
2) There is no good reason to set the tag in `ResourcesDecoder.decodeResources` rather than `ResTable.initApkInfo` that has reference to the `Config` object as well.
3) There is also no need for null-checking `mConfig.frameworkTag`, because if it's `null` then `info.tag` (which is already `null` by default) will simply be set to `null` again.