### PR TITLE
Fix LocaleNumberSystem + ConfigFlag reading

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResConfigFlags.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResConfigFlags.java
@@ -471,8 +471,11 @@ public class ResConfigFlags {
             if (localeVariant != null && localeVariant.length >= 5) {
                 sb.append("+").append(toUpper(localeVariant));
             }
+
+            // If we have a numbering system - it isn't used in qualifiers for build tools, but AOSP understands it
+            // So chances are - this may be valid, but aapt 1/2 will not like it.
             if (localeNumberingSystem != null && localeNumberingSystem.length > 0) {
-                sb.append("+n+nu+").append(localeNumberingSystem);
+                sb.append("+u+nu+").append(localeNumberingSystem);
             }
         }
         return sb.toString();

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResConfigFlags.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResConfigFlags.java
@@ -472,7 +472,7 @@ public class ResConfigFlags {
                 sb.append("+").append(toUpper(localeVariant));
             }
             if (localeNumberingSystem != null && localeNumberingSystem.length > 0) {
-                sb.append("-n-nu-").append(localeNumberingSystem);
+                sb.append("+n+nu+").append(localeNumberingSystem);
             }
         }
         return sb.toString();

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResConfigFlags.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResConfigFlags.java
@@ -51,6 +51,8 @@ public class ResConfigFlags {
     private final byte screenLayout2;
     private final byte colorMode;
 
+    private final char[] localeNumberingSystem;
+
     public final boolean isInvalid;
 
     private final String mQualifiers;
@@ -80,6 +82,7 @@ public class ResConfigFlags {
         localeVariant = null;
         screenLayout2 = 0;
         colorMode = COLOR_WIDE_UNDEFINED;
+        localeNumberingSystem = null;
         isInvalid = false;
         mQualifiers = "";
         size = 0;
@@ -92,7 +95,8 @@ public class ResConfigFlags {
                           short sdkVersion, byte screenLayout, byte uiMode,
                           short smallestScreenWidthDp, short screenWidthDp,
                           short screenHeightDp, char[] localeScript, char[] localeVariant,
-                          byte screenLayout2, byte colorMode, boolean isInvalid, int size) {
+                          byte screenLayout2, byte colorMode, char[] localeNumberingSystem,
+                          boolean isInvalid, int size) {
         if (orientation < 0 || orientation > 3) {
             LOGGER.warning("Invalid orientation value: " + orientation);
             orientation = 0;
@@ -157,6 +161,7 @@ public class ResConfigFlags {
         this.localeVariant = localeVariant;
         this.screenLayout2 = screenLayout2;
         this.colorMode = colorMode;
+        this.localeNumberingSystem = localeNumberingSystem;
         this.isInvalid = isInvalid;
         this.size = size;
         mQualifiers = generateQualifiers();
@@ -465,6 +470,9 @@ public class ResConfigFlags {
             }
             if (localeVariant != null && localeVariant.length >= 5) {
                 sb.append("+").append(toUpper(localeVariant));
+            }
+            if (localeNumberingSystem != null && localeNumberingSystem.length > 0) {
+                sb.append("-n-nu-").append(localeNumberingSystem);
             }
         }
         return sb.toString();

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
@@ -497,8 +497,8 @@ public class ARSCDecoder {
         char[] localeScript = null;
         char[] localeVariant = null;
         if (size >= 48) {
-            localeScript = readScriptOrVariantChar(4).toCharArray();
-            localeVariant = readScriptOrVariantChar(8).toCharArray();
+            localeScript = readVariantLengthString(4).toCharArray();
+            localeVariant = readVariantLengthString(8).toCharArray();
             read = 48;
         }
 
@@ -511,14 +511,14 @@ public class ARSCDecoder {
             read = 52;
         }
 
-        if (size > 52) {
-            int length = size - read;
-            mIn.skipBytes(length); // localeNumberingSystem
-            read += length;
+        char[] localeNumberingSystem = null;
+        if (size >= 60) {
+            localeNumberingSystem = readVariantLengthString(8).toCharArray();
+            read = 60;
         }
 
         int exceedingKnownSize = size - KNOWN_CONFIG_BYTES;
-        if (exceedingKnownSize > 0 && read < size) {
+        if (exceedingKnownSize > 0) {
             byte[] buf = new byte[exceedingKnownSize];
             read += exceedingKnownSize;
             mIn.readFully(buf);
@@ -545,7 +545,7 @@ public class ARSCDecoder {
                 inputFlags, screenWidth, screenHeight, sdkVersion,
                 screenLayout, uiMode, smallestScreenWidthDp, screenWidthDp,
                 screenHeightDp, localeScript, localeVariant, screenLayout2,
-                colorMode, isInvalid, size);
+                colorMode, localeNumberingSystem, isInvalid, size);
     }
 
     private char[] unpackLanguageOrRegion(byte in0, byte in1, char base) {
@@ -562,17 +562,17 @@ public class ARSCDecoder {
         return new char[] { (char) in0, (char) in1 };
     }
 
-    private String readScriptOrVariantChar(int length) throws IOException {
+    private String readVariantLengthString(int maxLength) throws IOException {
         StringBuilder string = new StringBuilder(16);
 
-        while (length-- != 0) {
+        while (maxLength-- != 0) {
             short ch = mIn.readByte();
             if (ch == 0) {
                 break;
             }
             string.append((char) ch);
         }
-        mIn.skipBytes(length);
+        mIn.skipBytes(maxLength);
 
         return string.toString();
     }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
@@ -514,7 +514,7 @@ public class ARSCDecoder {
         char[] localeNumberingSystem = null;
         if (size >= 60) {
             localeNumberingSystem = readVariantLengthString(8).toCharArray();
-            read = 68;
+            read = 60;
         }
 
         int exceedingKnownSize = size - KNOWN_CONFIG_BYTES;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
@@ -514,7 +514,7 @@ public class ARSCDecoder {
         char[] localeNumberingSystem = null;
         if (size >= 60) {
             localeNumberingSystem = readVariantLengthString(8).toCharArray();
-            read = 60;
+            read = 68;
         }
 
         int exceedingKnownSize = size - KNOWN_CONFIG_BYTES;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
@@ -517,10 +517,10 @@ public class ARSCDecoder {
             read += length;
         }
 
-        int exceedingSize = size - KNOWN_CONFIG_BYTES;
-        if (exceedingSize > 0) {
-            byte[] buf = new byte[exceedingSize];
-            read += exceedingSize;
+        int exceedingKnownSize = size - KNOWN_CONFIG_BYTES;
+        if (exceedingKnownSize > 0 && read < size) {
+            byte[] buf = new byte[exceedingKnownSize];
+            read += exceedingKnownSize;
             mIn.readFully(buf);
             BigInteger exceedingBI = new BigInteger(1, buf);
 

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/BuildAndDecodeTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/BuildAndDecodeTest.java
@@ -77,12 +77,12 @@ public class BuildAndDecodeTest extends BaseTest {
     }
 
     @Test
-    public void valuesBcp47NumericTest() throws BrutException {
+    public void valuesBcp47LanguageVariantTest() throws BrutException {
         compareValuesFiles("values-b+iw+660/strings.xml");
     }
 
     @Test
-    public void valuesBcp47NumberingTest() throws BrutException {
+    public void valuesBcp47LanguageScriptRegionVariantTest() throws BrutException {
         compareValuesFiles("values-b+ast+Latn+IT+AREVELA/strings.xml");
         compareValuesFiles("values-b+ast+Hant+IT+ARABEXT/strings.xml");
     }

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/BuildAndDecodeTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/BuildAndDecodeTest.java
@@ -82,6 +82,11 @@ public class BuildAndDecodeTest extends BaseTest {
     }
 
     @Test
+    public void valuesBcp47NumberingTest() throws BrutException {
+        compareValuesFiles("values-b+ast+Latn+IT+AREVELA/strings.xml");
+    }
+
+    @Test
     public void confirmZeroByteFileExtensionIsNotStored() throws BrutException {
         ApkInfo apkInfo = ApkInfo.load(sTestNewDir);
         assertFalse(apkInfo.doNotCompress.contains("jpg"));

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/BuildAndDecodeTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/BuildAndDecodeTest.java
@@ -77,6 +77,11 @@ public class BuildAndDecodeTest extends BaseTest {
     }
 
     @Test
+    public void valuesBcp47NumericTest() throws BrutException {
+        compareValuesFiles("values-b+iw+660/strings.xml");
+    }
+
+    @Test
     public void confirmZeroByteFileExtensionIsNotStored() throws BrutException {
         ApkInfo apkInfo = ApkInfo.load(sTestNewDir);
         assertFalse(apkInfo.doNotCompress.contains("jpg"));

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/BuildAndDecodeTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/BuildAndDecodeTest.java
@@ -84,6 +84,7 @@ public class BuildAndDecodeTest extends BaseTest {
     @Test
     public void valuesBcp47NumberingTest() throws BrutException {
         compareValuesFiles("values-b+ast+Latn+IT+AREVELA/strings.xml");
+        compareValuesFiles("values-b+ast+Hant+IT+ARABEXT/strings.xml");
     }
 
     @Test

--- a/brut.apktool/apktool-lib/src/test/resources/aapt2/testapp/res/values-b+ast+Hant+IT+ARABEXT/strings.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/aapt2/testapp/res/values-b+ast+Hant+IT+ARABEXT/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">testapp</string>
+</resources>

--- a/brut.apktool/apktool-lib/src/test/resources/aapt2/testapp/res/values-b+ast+Latn+IT+AREVELA/strings.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/aapt2/testapp/res/values-b+ast+Latn+IT+AREVELA/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">testapp</string>
+</resources>

--- a/brut.apktool/apktool-lib/src/test/resources/aapt2/testapp/res/values-b+de+CH+1901/strings.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/aapt2/testapp/res/values-b+de+CH+1901/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">testapp</string>
+</resources>

--- a/brut.apktool/apktool-lib/src/test/resources/aapt2/testapp/res/values-b+iw+660/strings.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/aapt2/testapp/res/values-b+iw+660/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">testapp</string>
+</resources>


### PR DESCRIPTION
During operations where we have more bytes than known (Upside down Cake). We improperly leveraged `size` even if we read over that. Additionally had to review some missing support on localeNumbering, which we always skipped.

* https://github.com/aosp-mirror/platform_frameworks_base/blob/9f086e5d7a13df28cc21cc07fadcdb4f2e667258/libs/androidfw/ResourceTypes.cpp#L3028
* http://www.unicode.org/reports/tr35/#UnicodeNumberSystemIdentifier
* https://developer.android.com/guide/topics/resources/providing-resources