### PR TITLE
feat: Introduce --no-compile-sdk-metadata

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/AaptInvoker.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/AaptInvoker.java
@@ -182,6 +182,8 @@ public class AaptInvoker {
 
         cmd.add("--allow-reserved-package-id");
 
+        cmd.add("--no-compile-sdk-metadata");
+
         if (mApkInfo.sparseResources) {
             cmd.add("--enable-sparse-encoding");
         }

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/DebuggableFalseChangeToTrueTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/DebuggableFalseChangeToTrueTest.java
@@ -75,9 +75,9 @@ public class DebuggableFalseChangeToTrueTest extends BaseTest {
         String apk = "issue2328-debuggable-flase-new";
 
         String expected = TestUtils.replaceNewlines("<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>" +
-                "<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\" android:compileSdkVersion=\"23\" " +
-                "android:compileSdkVersionCodename=\"6.0-2438415\" package=\"com.ibotpeaches.issue2328\" platformBuildVersionCode=\"23\" " +
-                "platformBuildVersionName=\"6.0-2438415\">    <application android:debuggable=\"true\"/></manifest>");
+            "<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\" " +
+            "package=\"com.ibotpeaches.issue2328\" platformBuildVersionCode=\"20\" " +
+            "platformBuildVersionName=\"4.4W.2-1537038\">    <application android:debuggable=\"true\"/></manifest>");
 
         byte[] encoded = Files.readAllBytes(Paths.get(sTmpDir + File.separator + apk + File.separator + "AndroidManifest.xml"));
         String obtained = TestUtils.replaceNewlines(new String(encoded));

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/DebuggableTrueAddedTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/DebuggableTrueAddedTest.java
@@ -75,9 +75,9 @@ public class DebuggableTrueAddedTest extends BaseTest {
         String apk = "issue2328-debuggable-missing-new";
 
         String expected = TestUtils.replaceNewlines("<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>" +
-                "<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\" android:compileSdkVersion=\"23\" " +
-                "android:compileSdkVersionCodename=\"6.0-2438415\" package=\"com.ibotpeaches.issue2328\" platformBuildVersionCode=\"23\" " +
-                "platformBuildVersionName=\"6.0-2438415\">    <application android:debuggable=\"true\"/></manifest>");
+            "<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\" " +
+            "package=\"com.ibotpeaches.issue2328\" platformBuildVersionCode=\"20\" " +
+            "platformBuildVersionName=\"4.4W.2-1537038\">    <application android:debuggable=\"true\"/></manifest>");
 
         byte[] encoded = Files.readAllBytes(Paths.get(sTmpDir + File.separator + apk + File.separator + "AndroidManifest.xml"));
         String obtained = TestUtils.replaceNewlines(new String(encoded));

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/DebuggableTrueRetainedTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/DebuggableTrueRetainedTest.java
@@ -75,9 +75,9 @@ public class DebuggableTrueRetainedTest extends BaseTest {
         String apk = "issue2328-debuggable-true-new";
 
         String expected = TestUtils.replaceNewlines("<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>" +
-                "<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\" android:compileSdkVersion=\"23\" " +
-                "android:compileSdkVersionCodename=\"6.0-2438415\" package=\"com.ibotpeaches.issue2328\" platformBuildVersionCode=\"23\" " +
-                "platformBuildVersionName=\"6.0-2438415\">    <application android:debuggable=\"true\"/></manifest>");
+            "<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\" " +
+            "package=\"com.ibotpeaches.issue2328\" platformBuildVersionCode=\"20\" " +
+            "platformBuildVersionName=\"4.4W.2-1537038\">    <application android:debuggable=\"true\"/></manifest>");
 
         byte[] encoded = Files.readAllBytes(Paths.get(sTmpDir + File.separator + apk + File.separator + "AndroidManifest.xml"));
         String obtained = TestUtils.replaceNewlines(new String(encoded));


### PR DESCRIPTION
Since changing/adapting values or keeping them the same requires continued patches to aapt2. This seems like the best way. We just don't use them.

refs: https://github.com/iBotPeaches/Apktool/discussions/3155
fixes: #3204 