### PR TITLE
fix: support skipping entries with NO_ENTRY (-1) flag

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
@@ -308,7 +308,7 @@ public class ARSCDecoder {
 
         for (int i : entryOffsetMap.keySet()) {
             int offset = entryOffsetMap.get(i);
-            if (offset == -1) {
+            if (offset == NO_ENTRY) {
                 continue;
             }
             mMissingResSpecMap.put(i, false);
@@ -318,12 +318,15 @@ public class ARSCDecoder {
             if (mCountIn.getCount() == mHeader.endPosition) {
                 int remainingEntries = entryCount - i;
                 LOGGER.warning(String.format("End of chunk hit. Skipping remaining entries (%d) in type: %s",
-                    remainingEntries, mTypeSpec.getName())
-                );
+                    remainingEntries, mTypeSpec.getName()
+                ));
                 break;
             }
 
-            readEntry(readEntryData());
+            EntryData entryData = readEntryData();
+            if (entryData != null) {
+                readEntry(entryData);
+            }
         }
 
         // skip "TYPE 8 chunks" and/or padding data at the end of this chunk
@@ -344,6 +347,10 @@ public class ARSCDecoder {
 
         short flags = mIn.readShort();
         int specNamesId = mIn.readInt();
+        if (specNamesId == NO_ENTRY) {
+            return null;
+        }
+
         ResValue value = (flags & ENTRY_FLAG_COMPLEX) == 0 ? readValue() : readComplexEntry();
         EntryData entryData = new EntryData();
         entryData.mFlags = flags;
@@ -661,6 +668,8 @@ public class ARSCDecoder {
     private final static short ENTRY_FLAG_WEAK = 0x0004;
 
     private static final int KNOWN_CONFIG_BYTES = 64;
+
+    private static final int NO_ENTRY = 0xFFFFFFFF;
 
     private static final Logger LOGGER = Logger.getLogger(ARSCDecoder.class.getName());
 }


### PR DESCRIPTION
fixes: #1874

In a very old (5+ year) issue. We saw a specific version of Google Hangouts failed to decode. Turns out with some fresh eyes. We just missed an important note in the spec that we should skip entries if the key/offset resolve to -1 (NO_ENTRY)

We applied that to the entry reading as well as the offset reading and it worked great to resolve what used to be this crash:

```
Caused by: java.io.IOException: Expected: 0x00000008, got: 0x00000202
	at brut.util.ExtDataInput.skipCheckShort(ExtDataInput.java:49)
	at brut.androlib.res.decoder.ARSCDecoder.readValue(ARSCDecoder.java:422)
	at brut.androlib.res.decoder.ARSCDecoder.readEntryData(ARSCDecoder.java:347)
	at brut.androlib.res.decoder.ARSCDecoder.readTableType(ARSCDecoder.java:326)
	at brut.androlib.res.decoder.ARSCDecoder.readResourceTable(ARSCDecoder.java:99)
	at brut.androlib.res.decoder.ARSCDecoder.decode(ARSCDecoder.java:50)
```