### PR TITLE
Explicit ResFileDecoder initialization in the decodeResources

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AXmlResourceParser.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AXmlResourceParser.java
@@ -20,6 +20,7 @@ import android.content.res.XmlResourceParser;
 import android.util.TypedValue;
 import brut.androlib.exceptions.AndrolibException;
 import brut.androlib.res.data.ResID;
+import brut.androlib.res.data.ResTable;
 import brut.androlib.res.data.arsc.ARSCHeader;
 import brut.androlib.res.data.axml.NamespaceStack;
 import brut.androlib.res.xml.ResXmlEncoders;
@@ -44,8 +45,9 @@ import java.util.logging.Logger;
  */
 public class AXmlResourceParser implements XmlResourceParser {
 
-    public AXmlResourceParser() {
+    public AXmlResourceParser(ResTable resTable) {
         resetEventInfo();
+        setAttrDecoder(new ResAttrDecoder(resTable));
     }
 
     public AndrolibException getFirstError() {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AndroidManifestResourceParser.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AndroidManifestResourceParser.java
@@ -17,6 +17,7 @@
 package brut.androlib.res.decoder;
 
 import android.util.TypedValue;
+import brut.androlib.res.data.ResTable;
 
 import java.util.regex.Pattern;
 
@@ -24,6 +25,10 @@ import java.util.regex.Pattern;
  * AXmlResourceParser specifically for parsing encoded AndroidManifest.xml.
  */
 public class AndroidManifestResourceParser extends AXmlResourceParser {
+
+    public AndroidManifestResourceParser(ResTable resTable) {
+        super(resTable);
+    }
 
     /**
      * Pattern for matching numeric string meta-data values. aapt automatically infers the

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResAttrDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResAttrDecoder.java
@@ -26,6 +26,11 @@ import brut.androlib.res.data.value.ResAttr;
 import brut.androlib.res.data.value.ResScalarValue;
 
 public class ResAttrDecoder {
+
+    public ResAttrDecoder(ResTable resTable) {
+        mResTable = resTable;
+    }
+
     public String decode(int type, int value, String rawValue, int attrResId)
         throws AndrolibException {
         ResScalarValue resValue = mResTable.getCurrentResPackage().getValueFactory().factory(type, value, rawValue);


### PR DESCRIPTION
AXmlResourceParser always set initialized ResAttrDecoder.

Add constructors ResAttrDecoder, AXmlResourceParser(ResTable resTable) and AndroidManifestResourceParser(ResTable resTable) for direct initialization resTable.