### PR TITLE
fix: adjust helper files to include system property sets

### DIFF
--- a/scripts/linux/apktool
+++ b/scripts/linux/apktool
@@ -53,7 +53,7 @@ javaOpts=""
 # line and adjust the value accordingly. Use "java -X" for a list of options
 # you can pass here.
 #
-javaOpts="-Xmx512M -Dfile.encoding=utf-8"
+javaOpts="-Xmx512M -Dfile.encoding=utf-8 -Djdk.util.zip.disableZip64ExtraFieldValidation=true -Djdk.nio.zipfs.allowDotZipEntry=true"
 
 # Alternatively, this will extract any parameter "-Jxxx" from the command line
 # and pass them to Java (instead of to dx). This makes it possible for you to

--- a/scripts/osx/apktool
+++ b/scripts/osx/apktool
@@ -53,7 +53,7 @@ javaOpts=""
 # line and adjust the value accordingly. Use "java -X" for a list of options
 # you can pass here.
 #
-javaOpts="-Xmx512M -Dfile.encoding=utf-8"
+javaOpts="-Xmx512M -Dfile.encoding=utf-8 -Djdk.util.zip.disableZip64ExtraFieldValidation=true -Djdk.nio.zipfs.allowDotZipEntry=true"
 
 # Alternatively, this will extract any parameter "-Jxxx" from the command line
 # and pass them to Java (instead of to dx). This makes it possible for you to

--- a/scripts/windows/apktool.bat
+++ b/scripts/windows/apktool.bat
@@ -36,7 +36,7 @@ if "%ATTR:~0,1%"=="-" if "%~x1"==".apk" (
 )
 
 :load
-"%java_exe%" -jar -Duser.language=en -Dfile.encoding=UTF8 "%~dp0%BASENAME%%max%.jar" %fastCommand% %*
+"%java_exe%" -jar -Duser.language=en -Dfile.encoding=UTF8 -Djdk.util.zip.disableZip64ExtraFieldValidation=true -Djdk.nio.zipfs.allowDotZipEntry=true "%~dp0%BASENAME%%max%.jar" %fastCommand% %*
 
 rem Pause when ran non interactively
 for /f "tokens=2" %%# in ("%cmdcmdline%") do if /i "%%#" equ "/c" pause


### PR DESCRIPTION
This is a test upgrade to the helper scripts to see if setting system properties works better than setting them within execution

fixes: #3198 