### PR TITLE
"--no-compile-sdk-metadata" tests.

### DIFF
--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/BaseTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/BaseTest.java
@@ -21,12 +21,13 @@ import brut.common.BrutException;
 import brut.directory.ExtFile;
 import brut.directory.FileDirectory;
 import org.custommonkey.xmlunit.*;
+import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.Reader;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.*;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
@@ -131,9 +132,35 @@ public class BaseTest {
         assertTrue(path + ": " + diff.getAllDifferences().toString(), diff.similar());
     }
 
+    protected static Document loadDocument(File file) throws IOException, SAXException, ParserConfigurationException {
+
+        DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+        docFactory.setFeature(FEATURE_DISABLE_DOCTYPE_DECL, true);
+        docFactory.setFeature(FEATURE_LOAD_DTD, false);
+
+        try {
+            docFactory.setAttribute(ACCESS_EXTERNAL_DTD, " ");
+            docFactory.setAttribute(ACCESS_EXTERNAL_SCHEMA, " ");
+        } catch (IllegalArgumentException ex) {
+            LOGGER.warning("JAXP 1.5 Support is required to validate XML");
+        }
+
+        DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+        // Not using the parse(File) method on purpose, so that we can control when
+        // to close it. Somehow parse(File) does not seem to close the file in all cases.
+        try (FileInputStream inputStream = new FileInputStream(file)) {
+            return docBuilder.parse(inputStream);
+        }
+    }
+
     protected static ExtFile sTmpDir;
     protected static ExtFile sTestOrigDir;
     protected static ExtFile sTestNewDir;
 
     protected final static Logger LOGGER = Logger.getLogger(BaseTest.class.getName());
+
+    private static final String ACCESS_EXTERNAL_DTD = "http://javax.xml.XMLConstants/property/accessExternalDTD";
+    private static final String ACCESS_EXTERNAL_SCHEMA = "http://javax.xml.XMLConstants/property/accessExternalSchema";
+    private static final String FEATURE_LOAD_DTD = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+    private static final String FEATURE_DISABLE_DOCTYPE_DECL = "http://apache.org/xml/features/disallow-doctype-decl";
 }

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/BuildAndDecodeTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/BuildAndDecodeTest.java
@@ -22,13 +22,22 @@ import brut.androlib.Config;
 import brut.common.BrutException;
 import brut.directory.ExtFile;
 import brut.util.OS;
+import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
 
+import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
+import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 import static org.junit.Assert.*;
 
 public class BuildAndDecodeTest extends BaseTest {
@@ -156,5 +165,24 @@ public class BuildAndDecodeTest extends BaseTest {
     @Test
     public void unknownFolderTest() throws BrutException {
         compareUnknownFiles();
+    }
+
+    @Test
+    public void confirmPlatformManifestValuesTest() throws IOException, SAXException, ParserConfigurationException {
+        Document doc = loadDocument(new File(sTestNewDir + "/AndroidManifest.xml"));
+        Node application = doc.getElementsByTagName("manifest").item(0);
+        NamedNodeMap attr = application.getAttributes();
+
+        Node platformBuildVersionNameAttr = attr.getNamedItem("platformBuildVersionName");
+        assertEquals("6.0-2438415", platformBuildVersionNameAttr.getNodeValue());
+
+        Node platformBuildVersionCodeAttr = attr.getNamedItem("platformBuildVersionCode");
+        assertEquals("23", platformBuildVersionCodeAttr.getNodeValue());
+
+        Node compileSdkVersionAttr = attr.getNamedItem("compileSdkVersion");
+        assertNull("compileSdkVersion should be stripped via aapt2", compileSdkVersionAttr);
+
+        Node compileSdkVersionCodenameAttr = attr.getNamedItem("compileSdkVersionCodename");
+        assertNull("compileSdkVersionCodename should be stripped via aapt2", compileSdkVersionCodenameAttr);
     }
 }

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/NetworkConfigTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/NetworkConfigTest.java
@@ -100,29 +100,4 @@ public class NetworkConfigTest extends BaseTest {
         Node debugAttr = attr.getNamedItem("android:networkSecurityConfig");
         assertEquals("@xml/network_security_config", debugAttr.getNodeValue());
     }
-
-    private static Document loadDocument(File file)
-        throws IOException, SAXException, ParserConfigurationException {
-
-        DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
-        docFactory.setFeature(FEATURE_DISABLE_DOCTYPE_DECL, true);
-        docFactory.setFeature(FEATURE_LOAD_DTD, false);
-
-        try {
-            docFactory.setAttribute(ACCESS_EXTERNAL_DTD, " ");
-            docFactory.setAttribute(ACCESS_EXTERNAL_SCHEMA, " ");
-        } catch (IllegalArgumentException ex) {
-            LOGGER.warning("JAXP 1.5 Support is required to validate XML");
-        }
-
-        DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
-        try (FileInputStream inputStream = new FileInputStream(file)) {
-            return docBuilder.parse(inputStream);
-        }
-    }
-
-    private static final String ACCESS_EXTERNAL_DTD = "http://javax.xml.XMLConstants/property/accessExternalDTD";
-    private static final String ACCESS_EXTERNAL_SCHEMA = "http://javax.xml.XMLConstants/property/accessExternalSchema";
-    private static final String FEATURE_LOAD_DTD = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
-    private static final String FEATURE_DISABLE_DOCTYPE_DECL = "http://apache.org/xml/features/disallow-doctype-decl";
 }

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/NetworkConfigTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/NetworkConfigTest.java
@@ -30,8 +30,6 @@ import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.xml.sax.SAXException;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.*;
 import java.nio.file.Files;

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/NoNetworkConfigTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/NoNetworkConfigTest.java
@@ -103,31 +103,4 @@ public class NoNetworkConfigTest extends BaseTest {
         Node debugAttr = attr.getNamedItem("android:networkSecurityConfig");
         assertEquals("@xml/network_security_config", debugAttr.getNodeValue());
     }
-
-    private static Document loadDocument(File file)
-        throws IOException, SAXException, ParserConfigurationException {
-
-        DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
-        docFactory.setFeature(FEATURE_DISABLE_DOCTYPE_DECL, true);
-        docFactory.setFeature(FEATURE_LOAD_DTD, false);
-
-        try {
-            docFactory.setAttribute(ACCESS_EXTERNAL_DTD, " ");
-            docFactory.setAttribute(ACCESS_EXTERNAL_SCHEMA, " ");
-        } catch (IllegalArgumentException ex) {
-            LOGGER.warning("JAXP 1.5 Support is required to validate XML");
-        }
-
-        DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
-        // Not using the parse(File) method on purpose, so that we can control when
-        // to close it. Somehow parse(File) does not seem to close the file in all cases.
-        try (FileInputStream inputStream = new FileInputStream(file)) {
-            return docBuilder.parse(inputStream);
-        }
-    }
-
-    private static final String ACCESS_EXTERNAL_DTD = "http://javax.xml.XMLConstants/property/accessExternalDTD";
-    private static final String ACCESS_EXTERNAL_SCHEMA = "http://javax.xml.XMLConstants/property/accessExternalSchema";
-    private static final String FEATURE_LOAD_DTD = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
-    private static final String FEATURE_DISABLE_DOCTYPE_DECL = "http://apache.org/xml/features/disallow-doctype-decl";
 }

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/NoNetworkConfigTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/NoNetworkConfigTest.java
@@ -30,11 +30,8 @@ import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.xml.sax.SAXException;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;


### PR DESCRIPTION
This should confirm that we no longer modify `platformBuildVersionCode` or `platformBuildVersionName` in aapt2. At the cost of stripping intentionally `compileSdkVersionCodename` and `compileSdkVersion` which I think is fair.