### PR TITLE
fix: Gradle wrapper validation trigger issue

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'gradle/wrapper/gradle-wrapper.jar'
   pull_request:
     paths:
-      - 'gradle/wrapper/**'
+      - 'gradle/wrapper/gradle-wrapper.jar'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Resolved the Gradle wrapper validation triggering problem by implementing a more precise check. Now, the validation process will only be triggered when there are actual changes in the gradle/wrapper/gradle-wrapper.jar file, preventing unnecessary validations.