### PR TITLE
fix: support duplicated namespaces

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/org/xmlpull/renamed/MXSerializer.java
+++ b/brut.apktool/apktool-lib/src/main/java/org/xmlpull/renamed/MXSerializer.java
@@ -19,7 +19,9 @@ package org.xmlpull.renamed;
 import org.xmlpull.v1.XmlSerializer;
 
 import java.io.*;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Implementation of XmlSerializer interface from XmlPull V1 API. This
@@ -646,14 +648,24 @@ public class MXSerializer implements XmlSerializer {
 	}
 
 	protected void writeNamespaceDeclarations() throws IOException {
+        Set<String> uniqueNamespaces = new HashSet<>();
 		for (int i = elNamespaceCount[depth - 1]; i < namespaceEnd; i++) {
-			if (doIndent && namespaceUri[i].length() > 40) {
+            String prefix = namespacePrefix[i];
+            String uri = namespaceUri[i];
+
+            // Some applications as seen in #2664 have duplicated namespaces.
+            // AOSP doesn't care, but the parser does. So we filter them out.
+            if (uniqueNamespaces.contains(prefix + uri)) {
+                continue;
+            }
+
+			if (doIndent && uri.length() > 40) {
 				writeIndent();
 				out.write(" ");
 			}
-			if (namespacePrefix[i] != "") {
+			if (prefix != "") {
 				out.write(" xmlns:");
-				out.write(namespacePrefix[i]);
+				out.write(prefix);
 				out.write('=');
 			} else {
 				out.write(" xmlns=");
@@ -661,8 +673,10 @@ public class MXSerializer implements XmlSerializer {
 			out.write(attributeUseApostrophe ? '\'' : '"');
 
 			// NOTE: escaping of namespace value the same way as attributes!!!!
-			writeAttributeValue(namespaceUri[i], out);
+			writeAttributeValue(uri, out);
 			out.write(attributeUseApostrophe ? '\'' : '"');
+
+            uniqueNamespaces.add(prefix + uri);
 		}
 	}
 


### PR DESCRIPTION
In some applications we find duplicate namespaces. This because we move onward to common XML tools to extract/modify end up crashing.

```
I: Loading resource table...
I: Decoding AndroidManifest.xml with resources...
I: Regular manifest package...
[Fatal Error] :5:61: Attribute "xmlns:android" was already specified for element "manifest".
```

These were indeed duplicates so it was not Apktool introducing them.

```
➜  2664 aapt2 d xmltree 2664.apk --file AndroidManifest.xml | more
N: android=http://schemas.android.com/apk/res/android (line=4294967295)
  N: amazon=http://schemas.amazon.com/apk/res/android (line=4294967295)
    N: android=http://schemas.android.com/apk/res/android (line=4294967295)
```

So we maintain a mapping of prefix/uri and skip it if we encounter it again. This happens at writing time so we don't have to mess with indexes/stacks. 

fixes: #2664 