### PR TITLE
fix: resolve missing namespace on system resources

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AXmlResourceParser.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AXmlResourceParser.java
@@ -276,6 +276,15 @@ public class AXmlResourceParser implements XmlResourceParser {
     public String getAttributeNamespace(int index) {
         int offset = getAttributeOffset(index);
         int namespace = mAttributes[offset + ATTRIBUTE_IX_NAMESPACE_URI];
+
+        // #2972 - If the namespace index is -1, the attribute is not present, but if the attribute is from system
+        // we can resolve it to the default namespace. This may prove to be too aggressive as we scope the entire
+        // system namespace, but it is better than not resolving it at all.
+        ResID resId = new ResID(getAttributeNameResource(index));
+        if (resId.pkgId == 1 && namespace == -1) {
+            return ANDROID_RES_NS;
+        }
+
         if (namespace == -1) {
             return "";
         }
@@ -284,12 +293,11 @@ public class AXmlResourceParser implements XmlResourceParser {
         // unless the pkgId of the resource is private. We will grab the non-standard one.
         String value = mStringBlock.getString(namespace);
 
-        if (value == null || value.length() == 0) {
-            ResID resId = new ResID(getAttributeNameResource(index));
+        if (value == null || value.isEmpty()) {
             if (resId.pkgId == PRIVATE_PKG_ID) {
-                value = getNonDefaultNamespaceUri(offset);
+                return getNonDefaultNamespaceUri(offset);
             } else {
-                value = "http://schemas.android.com/apk/res/android";
+                return ANDROID_RES_NS;
             }
         }
 
@@ -308,7 +316,7 @@ public class AXmlResourceParser implements XmlResourceParser {
         // We have the namespaces that can't be touched in the opening tag.
         // Though no known way to correlate them at this time.
         // So return the res-auto namespace.
-        return "http://schemas.android.com/apk/res-auto";
+        return ANDROID_RES_NS_AUTO;
     }
 
     @Override
@@ -828,4 +836,7 @@ public class AXmlResourceParser implements XmlResourceParser {
     private static final int ATTRIBUTE_LENGTH = 5;
 
     private static final int PRIVATE_PKG_ID = 0x7F;
+
+    private static final String ANDROID_RES_NS_AUTO = "http://schemas.android.com/apk/res-auto";
+    private static final String ANDROID_RES_NS = "http://schemas.android.com/apk/res/android";
 }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AXmlResourceParser.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AXmlResourceParser.java
@@ -281,7 +281,7 @@ public class AXmlResourceParser implements XmlResourceParser {
         // we can resolve it to the default namespace. This may prove to be too aggressive as we scope the entire
         // system namespace, but it is better than not resolving it at all.
         ResID resId = new ResID(getAttributeNameResource(index));
-        if (resId.pkgId == 1 && namespace == -1) {
+        if (namespace == -1 && resId.pkgId == 1) {
             return ANDROID_RES_NS;
         }
 


### PR DESCRIPTION
In some applications we see the associated namespace is stripped completely.

```
➜  2972 aapt2 dump xmltree base.apk --file AndroidManifest.xml
N: android=http://schemas.android.com/apk/res/android (line=0)
  E: manifest (line=0)
    A: http://schemas.android.com/apk/res/android:versionCode(0x0101021b)=23608
    A: (0x0101021c)="2.36.8" (Raw: "2.36.8")
    A: (0x01010572)=30
    A: (0x01010573)="11" (Raw: "11")
    A: package="com.bcp.innovacxion.yapeapp" (Raw: "com.bcp.innovacxion.yapeapp")
    A: platformBuildVersionCode=30
    A: platformBuildVersionName=11
      E: uses-sdk (line=0)
        A: (0x0101020c)=21
        A: (0x01010270)=30
      E: supports-screens (line=0)
        A: (0x0101026c)=true
        A: (0x01010284)=true
        A: (0x01010285)=true
        A: (0x01010286)=true
        A: (0x0101028d)=true
        A: (0x010102bf)=true
```

The fix here in theory is easy - resolve resourceId and if you know its a manifest attribute - use it. However that would require us to track all manifest attributes much like `android.R.attr`.

So this first approach will use any system resource only if the manifest prefix resolved to nothing. This seems safe because we won't touch internal resources or private.

fixes: #2972 