### PR TITLE
Move to XMLUnit Legacy

### DIFF
--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/BaseTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/BaseTest.java
@@ -115,6 +115,8 @@ public class BaseTest {
             Reader control = new FileReader(new File(sTestOrigDir, path));
             Reader test = new FileReader(new File(sTestNewDir, path));
 
+            XMLUnit.setEnableXXEProtection(true);
+
             if (qualifier == null) {
                 XMLUnit.setIgnoreWhitespace(true);
                 XMLUnit.setIgnoreAttributeOrder(true);

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ buildscript {
                 proguard_gradle: 'com.guardsquare:proguard-gradle:7.3.2',
                 smali          : 'com.android.tools.smali:smali:3.0.3',
                 xmlpull        : 'xpp3:xpp3:1.1.4c',
-                xmlunit        : 'xmlunit:xmlunit:1.6',
+                xmlunit        : 'org.xmlunit:xmlunit-legacy:2.9.1',
         ]
     }
 


### PR DESCRIPTION
The old location of XMLUnit has ended. The proper path here is to migrate towards XMLUnit 2.x, but it looks like a challenge to rewrite our XML diff.

For now, a jump to the 2.x port of v1 can gain us an XXE Protection in case malicious test files exist during the build (of apktool). Which honestly I don't think would ever happen as if you have to control of a system that is building apktool itself and have the power to edit/change XML files - you could do more damage.

Part of me also wants to go into a CVE rant about honestly garbage CVEs, but lets upgrade this with 1 line changed to "quiet" some garbage automated scan and be done with this.