### PR TITLE
Remove Apktool Dummys.

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResPackage.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResPackage.java
@@ -127,10 +127,6 @@ public class ResPackage {
         return mSynthesizedRes.contains(resId);
     }
 
-    public void removeResSpec(ResResSpec spec) {
-        mResSpecs.remove(spec.getId());
-    }
-
     public void addResSpec(ResResSpec spec) throws AndrolibException {
         if (mResSpecs.put(spec.getId(), spec) != null) {
             throw new AndrolibException("Multiple resource specs: " + spec);

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResResSpec.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResResSpec.java
@@ -105,10 +105,6 @@ public class ResResSpec {
         return mType;
     }
 
-    public boolean isDummyResSpec() {
-        return getName().startsWith("APKTOOL_DUMMY_");
-    }
-
     public void addResource(ResResource res) throws AndrolibException {
         addResource(res, false);
     }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResTypeSpec.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResTypeSpec.java
@@ -30,18 +30,11 @@ public final class ResTypeSpec {
     private final String mName;
     private final Map<String, ResResSpec> mResSpecs = new LinkedHashMap<>();
 
-    private final ResTable mResTable;
-    private final ResPackage mPackage;
-
     private final int mId;
-    private final int mEntryCount;
 
-    public ResTypeSpec(String name, ResTable resTable, ResPackage package_, int id, int entryCount) {
+    public ResTypeSpec(String name, int id) {
         this.mName = name;
-        this.mResTable = resTable;
-        this.mPackage = package_;
         this.mId = id;
-        this.mEntryCount = entryCount;
     }
 
     public String getName() {
@@ -66,10 +59,6 @@ public final class ResTypeSpec {
 
     public ResResSpec getResSpecUnsafe(String name) {
         return mResSpecs.get(name);
-    }
-
-    public void removeResSpec(ResResSpec spec) {
-        mResSpecs.remove(spec.getName());
     }
 
     public void addResSpec(ResResSpec spec) throws AndrolibException {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResScalarValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResScalarValue.java
@@ -81,11 +81,6 @@ public abstract class ResScalarValue extends ResIntBasedValue implements
             }
         }
 
-        // Dummy attributes should be <item> with type attribute
-        if (res.getResSpec().isDummyResSpec()) {
-            item = true;
-        }
-
         // Android does not allow values (false) for ids.xml anymore
         // https://issuetracker.google.com/issues/80475496
         // But it decodes as a ResBoolean, which makes no sense. So force it to empty


### PR DESCRIPTION
First requested by @MrIkso a few years ago in https://github.com/iBotPeaches/Apktool/pull/2463. It was recently broken a few releases back during the sparse resource fixes.

No one really noticed that these were missing and it turns out in a variety of tests - you don't really need them. All they do is bloat codebase, bloat application and unneeded. I may be proven wrong quickly after the removal of this, but since it actually hasn't been working in a year - I think its fair to say no one needs this.