### PR TITLE
build: upgrade to shadow build 8.1.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,19 +66,10 @@ if ("release" !in gradle.startParameter.taskNames) {
 }
 
 plugins {
+    id("com.github.johnrengelman.shadow") version "8.1.1"
     `java-library`
     `maven-publish`
     signing
-}
-
-buildscript {
-    repositories {
-        gradlePluginPortal()
-        google()
-    }
-    dependencies {
-        classpath("gradle.plugin.com.github.johnrengelman:shadow:8.0.0")
-    }
 }
 
 java {


### PR DESCRIPTION
Noticed in https://github.com/iBotPeaches/Apktool/pull/3255 - that shadow was out of date and we could drop the legacy `buildscript` logic for Kotlin DSL plugins.