### PR TITLE
Refactor logging for chunks and sparse flags.

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResTable.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResTable.java
@@ -256,8 +256,10 @@ public class ResTable {
     }
 
     public void setSparseResources(boolean flag) {
+        if (mApkInfo.sparseResources != flag) {
+            LOGGER.info("Sparsely packed resources detected.");
+        }
         mApkInfo.sparseResources = flag;
-
     }
 
     public void clearSdkInfo() {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
@@ -271,9 +271,6 @@ public class ARSCDecoder {
         mHeader.checkForUnreadHeader(mIn);
 
         if ((typeFlags & 0x01) != 0) {
-            LOGGER.fine("Sparse type flags detected: " + mTypeSpec.getName());
-
-            // We've detected sparse resources, lets record this so we can rebuild in that same format
             mResTable.setSparseResources(true);
         }
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
@@ -65,10 +65,15 @@ public class ARSCDecoder {
         Set<ResPackage> pkgs = new LinkedHashSet<>();
 
         ResTypeSpec typeSpec;
+        int chunkNumber = 1;
 
         chunkLoop:
         for (;;) {
             nextChunk();
+
+            LOGGER.fine(String.format(
+                "Chunk #%d start: type=0x%04x chunkSize=0x%08x", chunkNumber++, mHeader.type, mHeader.chunkSize
+            ));
 
             switch (mHeader.type) {
                 case ARSCHeader.RES_NULL_TYPE:

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResFileDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResFileDecoder.java
@@ -62,7 +62,7 @@ public class ResFileDecoder {
             resFileMapping.put(inFilePath, outFilePath);
         }
 
-        LOGGER.fine("Decoding file: " + inFilePath + " to: " + outFilePath);
+        LOGGER.fine("Decoding file " + inFilePath + " to " + outFilePath);
 
         try {
             if (typeName.equals("raw")) {


### PR DESCRIPTION
This is a bit quieter now.

```
I: Using Apktool v2.8.1-41-0e226928-SNAPSHOT on 1407.apk
I: Loading resource table...
I: Decoding file-resources...
I: Loading resource table from file: /home/ibotpeaches/.local/share/apktool/framework/1.apk
I: Sparsely packed resources detected.
```

Now for chunks we can find out where we crash to easily find the chunk prior to the bad one.

```
FINE: Chunk #70 start: type=0x0202 chunkSize=0x00000030
FINE: Chunk #71 start: type=0x0201 chunkSize=0x000000f4
FINE: Chunk #72 start: type=0x0202 chunkSize=0x00001904
FINE: Chunk #73 start: type=0x3eb0 chunkSize=0x00003ec0
SEVERE: Unknown chunk type: 3eb0
INFO: Decoding file-resources...
````