### PR TITLE
docs: clarify build file on build doc

### DIFF
--- a/docs/build.mdx
+++ b/docs/build.mdx
@@ -25,11 +25,11 @@ We use gradle to build. First clone the repository using either
 
 1. Navigate to the Apktool folder: `cd Apktool`
 2. For remaining steps use `./gradlew` for unix based systems or `gradlew.bat` for windows.
-3. `[./gradlew][gradlew.bat] build shadowJar` - Builds Apktool, including final binary.
-4. Optional (You may build a Proguard jar) `[./gradlew][gradlew.bat] build shadowJar proguard`
-
-After build completes you should have a bunch of jar files built. The best one to use is:
-`./brut.apktool/apktool-cli/build/libs/apktool-cli-all.jar`
+3. You can build the project in two ways:
+    1. Without proguard `[./gradlew][gradlew.bat] build shadowJar`
+        - This will build the project and create a jar file: `brut.apktool/apktool-cli/build/libs/apktool-cli-all.jar`        
+    2. With proguard: `[./gradlew][gradlew.bat] build shadowJar proguard`
+        - This will build the project and create a jar file: `brut.apktool/apktool-cli/build/libs/apktool-vXXX.jar`
 
 #### Windows Requirements
 

--- a/docs/build.mdx
+++ b/docs/build.mdx
@@ -27,7 +27,7 @@ We use gradle to build. First clone the repository using either
 2. For remaining steps use `./gradlew` for unix based systems or `gradlew.bat` for windows.
 3. You can build the project in two ways:
    1. Without proguard `[./gradlew][gradlew.bat] build shadowJar`
-      - This will build the project and create a jar file: `brut.apktool/apktool-cli/build/libs/apktool-cli-all.jar`        
+      - This will build the project and create a jar file: `brut.apktool/apktool-cli/build/libs/apktool-cli-all.jar`
    2. With proguard: `[./gradlew][gradlew.bat] build shadowJar proguard`
       - This will build the project and create a jar file: `brut.apktool/apktool-cli/build/libs/apktool-vXXX.jar`
 

--- a/docs/build.mdx
+++ b/docs/build.mdx
@@ -23,13 +23,13 @@ Apktool is a collection of 1 project, containing subprojects and a few dependenc
 We use gradle to build. First clone the repository using either
 [SSH](ssh://git@github.com:iBotPeaches/Apktool.git) or [HTTPS](https://github.com/iBotPeaches/Apktool.git).
 
-1. `cd Apktool`
+1. Navigate to the Apktool folder: `cd Apktool`
 2. For remaining steps use `./gradlew` for unix based systems or `gradlew.bat` for windows.
 3. `[./gradlew][gradlew.bat] build shadowJar` - Builds Apktool, including final binary.
 4. Optional (You may build a Proguard jar) `[./gradlew][gradlew.bat] build shadowJar proguard`
 
-After build completes you should have a jar file at:
-`./brut.apktool/apktool-cli/build/libs/apktool-xxxxx.jar`
+After build completes you should have a bunch of jar files built. The best one to use is:
+`./brut.apktool/apktool-cli/build/libs/apktool-cli-all.jar`
 
 #### Windows Requirements
 

--- a/docs/build.mdx
+++ b/docs/build.mdx
@@ -26,10 +26,10 @@ We use gradle to build. First clone the repository using either
 1. Navigate to the Apktool folder: `cd Apktool`
 2. For remaining steps use `./gradlew` for unix based systems or `gradlew.bat` for windows.
 3. You can build the project in two ways:
-    1. Without proguard `[./gradlew][gradlew.bat] build shadowJar`
-        - This will build the project and create a jar file: `brut.apktool/apktool-cli/build/libs/apktool-cli-all.jar`        
-    2. With proguard: `[./gradlew][gradlew.bat] build shadowJar proguard`
-        - This will build the project and create a jar file: `brut.apktool/apktool-cli/build/libs/apktool-vXXX.jar`
+   1. Without proguard `[./gradlew][gradlew.bat] build shadowJar`
+      - This will build the project and create a jar file: `brut.apktool/apktool-cli/build/libs/apktool-cli-all.jar`        
+   2. With proguard: `[./gradlew][gradlew.bat] build shadowJar proguard`
+      - This will build the project and create a jar file: `brut.apktool/apktool-cli/build/libs/apktool-vXXX.jar`
 
 #### Windows Requirements
 


### PR DESCRIPTION
Following the build docs and found that there were a few `*.jar` files the described build folder.
I found that the `apktool-cli-all.jar` file was the one that worked for me whereas the `apk-cli.jar` file returned an error that there was no manifest.
Here, I made the filename a bit more specific so others don't have to test.
Let me know if this is mistaken.