### PR TITLE
Prevent poisioning mResTable if Framework is sparse.

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
@@ -270,7 +270,9 @@ public class ARSCDecoder {
 
         mHeader.checkForUnreadHeader(mIn);
 
-        if ((typeFlags & 0x01) != 0) {
+        // Be sure we don't poison mResTable by marking the application as sparse
+        // Only flag the ResTable as sparse if the main package is not loaded.
+        if ((typeFlags & 0x01) != 0 && !mResTable.isMainPkgLoaded()) {
             mResTable.setSparseResources(true);
         }
 

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/SparseFlagTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/decode/SparseFlagTest.java
@@ -54,6 +54,7 @@ public class SparseFlagTest extends BaseTest {
 
         LOGGER.info("Decoding sparse.apk...");
         Config config = Config.getDefaultConfig();
+        config.frameworkTag = "issue-3298";
 
         ApkDecoder apkDecoder = new ApkDecoder(config, testApk);
         ApkInfo apkInfo = apkDecoder.decode(sTestNewDir);
@@ -70,6 +71,7 @@ public class SparseFlagTest extends BaseTest {
 
         LOGGER.info("Decoding not-sparse.apk...");
         Config config = Config.getDefaultConfig();
+        config.frameworkTag = "issue-3298";
 
         ApkDecoder apkDecoder = new ApkDecoder(config, testApk);
         ApkInfo apkInfo = apkDecoder.decode(sTestNewDir);


### PR DESCRIPTION
We have a leaking issue where we populate mApkInfo during each decode, which may be n (each framework). These values are all stored in 1 location. We can prevent setting the sparse flag if we've already loaded the main packages (pkgs within resources.arsc).

fixes: #3298 