### PR TITLE
fix: temporary workaround of skipping dummy resources

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResEnumAttr.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResEnumAttr.java
@@ -50,12 +50,15 @@ public class ResEnumAttr extends ResAttr {
             throws AndrolibException, IOException {
         for (Duo<ResReferenceValue, ResIntValue> duo : mItems) {
             int intVal = duo.m2.getValue();
+            // #2836 - As a temporary workaround due to "bugged" dummy resources. Skip adding an enum
+            // if we have no reference to the resource.
             ResResSpec m1Referent = duo.m1.getReferent();
+            if (m1Referent == null) {
+                continue;
+            }
 
             serializer.startTag(null, "enum");
-            serializer.attribute(null, "name",
-                    m1Referent != null ? m1Referent.getName() : "@null"
-            );
+            serializer.attribute(null, "name", m1Referent.getName());
             serializer.attribute(null, "value", String.valueOf(intVal));
             serializer.endTag(null, "enum");
         }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResFlagsAttr.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResFlagsAttr.java
@@ -17,6 +17,7 @@
 package brut.androlib.res.data.value;
 
 import brut.androlib.exceptions.AndrolibException;
+import brut.androlib.res.data.ResResSpec;
 import brut.androlib.res.data.ResResource;
 import brut.util.Duo;
 import org.xmlpull.v1.XmlSerializer;
@@ -73,10 +74,16 @@ public class ResFlagsAttr extends ResAttr {
     protected void serializeBody(XmlSerializer serializer, ResResource res)
             throws AndrolibException, IOException {
         for (FlagItem item : mItems) {
+            // #2836 - As a temporary workaround due to "bugged" dummy resources. Skip adding a flag
+            // if we have no reference to the resource.
+            ResResSpec referent = item.ref.getReferent();
+            if (referent == null) {
+                continue;
+            }
+
             serializer.startTag(null, "flag");
             serializer.attribute(null, "name", item.getValue());
-            serializer.attribute(null, "value",
-                String.format("0x%08x", item.flag));
+            serializer.attribute(null, "value", String.format("0x%08x", item.flag));
             serializer.endTag(null, "flag");
         }
     }


### PR DESCRIPTION
refs: #2836 

---

This is a workaround where we toss any bag/flag item where we can't resolve the reference. This pattern we keep during serialization of styles.