### PR TITLE
refactor: verbose doesn't adapt handler

### DIFF
--- a/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
+++ b/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
@@ -592,11 +592,18 @@ public class Main {
             return;
         }
 
-        Handler handler = new Handler(){
+        Handler handler = new Handler() {
             @Override
             public void publish(LogRecord record) {
                 if (getFormatter() == null) {
-                    setFormatter(new SimpleFormatter());
+                    setFormatter(new Formatter() {
+                        @Override
+                        public String format(LogRecord record) {
+                            return record.getLevel().toString().charAt(0) + ": "
+                                + record.getMessage()
+                                + System.getProperty("line.separator");
+                        }
+                    });
                 }
 
                 try {
@@ -616,6 +623,7 @@ public class Main {
                     reportError(null, exception, ErrorManager.FORMAT_FAILURE);
                 }
             }
+
             @Override
             public void close() throws SecurityException {}
             @Override
@@ -627,15 +635,6 @@ public class Main {
         if (verbosity == Verbosity.VERBOSE) {
             handler.setLevel(Level.ALL);
             logger.setLevel(Level.ALL);
-        } else {
-            handler.setFormatter(new Formatter() {
-                @Override
-                public String format(LogRecord record) {
-                    return record.getLevel().toString().charAt(0) + ": "
-                            + record.getMessage()
-                            + System.getProperty("line.separator");
-                }
-            });
         }
     }
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
@@ -207,7 +207,7 @@ public class ARSCDecoder {
         mHeader.checkForUnreadHeader(mIn);
 
         for (int i = 0; i < count; i++) {
-            LOGGER.fine(String.format("Skipping staged alias stagedId (%h) finalId: %h", mIn.readInt(), mIn.readInt()));
+            LOGGER.fine(String.format("Staged alias: 0x%08x -> 0x%08x", mIn.readInt(), mIn.readInt()));
         }
     }
 


### PR DESCRIPTION
This has become way too verbose. I can't even easily grep what I want. Dumping method names just isn't helpful - the helpful log messages that are emitted during verbose is all we need.

prior:
```
Sep 03, 2023 6:19:55 AM brut.androlib.ApkDecoder decode
INFO: Using Apktool v2.8.1-54-06c5f462-SNAPSHOT on Kate.apk
Sep 03, 2023 6:19:55 AM brut.androlib.res.data.ResTable loadMainPkg
INFO: Loading resource table...
Sep 03, 2023 6:19:55 AM brut.androlib.res.decoder.ARSCDecoder readResourceTable
FINE: Chunk #1 start: type=0x0002 chunkSize=0x0010ca40
```

now:
```
I: Using Apktool v2.8.1-54-06c5f462-SNAPSHOT on Kate.apk
I: Loading resource table...
F: Chunk #1 start: type=0x0002 chunkSize=0x0010ca40
```