### PR TITLE
Support Disassembly of mega old Android (M5)

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
@@ -260,10 +260,16 @@ public class ARSCDecoder {
     private ResType readTableType() throws IOException, AndrolibException {
         checkChunkType(ARSCHeader.XML_TYPE_TYPE);
         int typeId = mIn.readUnsignedByte() - mTypeIdOffset;
+
+        // #3311 - Some older applications have no TYPE_SPEC chunks, but still define TYPE chunks.
         if (mResTypeSpecs.containsKey(typeId)) {
-            mResId = (0xff000000 & mResId) | mResTypeSpecs.get(typeId).getId() << 16;
             mTypeSpec = mResTypeSpecs.get(typeId);
+        } else {
+            mTypeSpec = new ResTypeSpec(mTypeNames.getString(typeId - 1), typeId);
+            addTypeSpec(mTypeSpec);
+            mPkg.addType(mTypeSpec);
         }
+        mResId = (0xff000000 & mResId) | mTypeSpec.getId() << 16;
 
         int typeFlags = mIn.readByte();
         mIn.skipBytes(2); // reserved


### PR DESCRIPTION
fixes: #3311

--

```
F: Chunk #1 start: type=0x0002 chunkSize=0x0002c8fc
F: Chunk #2 start: type=0x0001 chunkSize=0x00010f84
F: Chunk #3 start: type=0x0200 chunkSize=0x0001b96c
F: Chunk #4 start: type=0x0201 chunkSize=0x00003b80
```

The sample included in #3311 is from 2008 Milestone Android builds, which is pre-1.0. Prior to any API stabilization so we can see that they don't have TYPE_SPECS. We can survive disassembly by just making types on the fly if we didn't find one.