### PR TITLE
fix: enforce java 1.8 compatibility with built artifacts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,11 +72,6 @@ plugins {
     signing
 }
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 tasks.withType<JavaCompile> {
     options.compilerArgs.add("-Xlint:-options")
     options.compilerArgs.add("--release 8")
@@ -94,6 +89,11 @@ allprojects {
 subprojects {
     apply(plugin = "java")
     apply(plugin = "java-library")
+
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 
     val mavenProjects = arrayOf("apktool-lib", "apktool-cli", "brut.j.common", "brut.j.util", "brut.j.dir")
 


### PR DESCRIPTION
As reported in XDA - https://forum.xda-developers.com/t/util-jul-22-2023-apktool-tool-for-reverse-engineering-apk-files.1755243/page-305#post-88993197

We somehow broke the compatibility with older Java's. This previously would take the toolchain version of the JDK. Now we enforce 1.8