### PR TITLE
build: migrate towards "libs.versions.toml"

### DIFF
--- a/brut.apktool/apktool-cli/build.gradle.kts
+++ b/brut.apktool/apktool-cli/build.gradle.kts
@@ -1,10 +1,9 @@
 import proguard.gradle.ProGuardTask
 
-val commonsCliVersion: String by rootProject.extra
 val apktoolVersion: String by rootProject.extra
 
 plugins {
-    id("com.github.johnrengelman.shadow")
+    alias(libs.plugins.shadow)
     application
 }
 
@@ -14,12 +13,12 @@ plugins {
 buildscript {
     dependencies {
         // Proguard doesn't support plugin DSL - https://github.com/Guardsquare/proguard/issues/225
-        classpath("com.guardsquare:proguard-gradle:7.3.2")
+        classpath(libs.proguard)
     }
 }
 
 dependencies {
-    implementation("commons-cli:commons-cli:$commonsCliVersion")
+    implementation(libs.commons.cli)
     implementation(project(":brut.apktool:apktool-lib"))
 }
 

--- a/brut.apktool/apktool-lib/build.gradle.kts
+++ b/brut.apktool/apktool-lib/build.gradle.kts
@@ -1,13 +1,3 @@
-val baksmaliVersion: String by rootProject.extra
-val smaliVersion: String by rootProject.extra
-val xmlpullVersion: String by rootProject.extra
-val guavaVersion: String by rootProject.extra
-val commonsLangVersion: String by rootProject.extra
-val commonsIoVersion: String by rootProject.extra
-val commonsTextVersion: String by rootProject.extra
-val junitVersion: String by rootProject.extra
-val xmlunitVersion: String by rootProject.extra
-
 val gitRevision: String by rootProject.extra
 val apktoolVersion: String by rootProject.extra
 
@@ -39,14 +29,14 @@ dependencies {
     api(project(":brut.j.util"))
     api(project(":brut.j.common"))
 
-    implementation("com.android.tools.smali:smali-baksmali:$baksmaliVersion")
-    implementation("com.android.tools.smali:smali:$smaliVersion")
-    implementation("xpp3:xpp3:$xmlpullVersion")
-    implementation("com.google.guava:guava:$guavaVersion")
-    implementation("org.apache.commons:commons-lang3:$commonsLangVersion")
-    implementation("commons-io:commons-io:$commonsIoVersion")
-    implementation("org.apache.commons:commons-text:$commonsTextVersion")
+    implementation(libs.baksmali)
+    implementation(libs.smali)
+    implementation(libs.xmlpull)
+    implementation(libs.guava)
+    implementation(libs.commons.lang3)
+    implementation(libs.commons.io)
+    implementation(libs.commons.text)
 
-    testImplementation("junit:junit:$junitVersion")
-    testImplementation("org.xmlunit:xmlunit-legacy:$xmlunitVersion")
+    testImplementation(libs.junit)
+    testImplementation(libs.xmlunit)
 }

--- a/brut.j.dir/build.gradle.kts
+++ b/brut.j.dir/build.gradle.kts
@@ -1,7 +1,5 @@
-val commonsIoVersion: String by rootProject.extra
-
 dependencies {
   implementation(project(":brut.j.common"))
   implementation(project(":brut.j.util"))
-  implementation("commons-io:commons-io:$commonsIoVersion")
+  implementation(libs.commons.io)
 }

--- a/brut.j.util/build.gradle.kts
+++ b/brut.j.util/build.gradle.kts
@@ -1,8 +1,5 @@
-val commonsIoVersion: String by rootProject.extra
-val guavaVersion: String by rootProject.extra
-
 dependencies {
     implementation(project(":brut.j.common"))
-    implementation("commons-io:commons-io:$commonsIoVersion")
-    implementation("com.google.guava:guava:$guavaVersion")
+    implementation(libs.commons.io)
+    implementation(libs.guava)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,16 +1,5 @@
 import java.io.ByteArrayOutputStream
 
-val baksmaliVersion by extra("3.0.3")
-val commonsCliVersion by extra("1.5.0")
-val commonsIoVersion by extra("2.13.0")
-val commonsLangVersion by extra("3.13.0")
-val commonsTextVersion by extra("1.10.0")
-val guavaVersion by extra("32.0.1-jre")
-val junitVersion by extra("4.13.2")
-val smaliVersion by extra("3.0.3")
-val xmlpullVersion by extra("1.1.4c")
-val xmlunitVersion by extra("2.9.1")
-
 val version = "2.8.2"
 val suffix = "SNAPSHOT"
 
@@ -66,7 +55,7 @@ if ("release" !in gradle.startParameter.taskNames) {
 }
 
 plugins {
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    alias(libs.plugins.shadow)
     `java-library`
     `maven-publish`
     signing

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,29 @@
+[versions]
+baksmali = "3.0.3"
+commons_io = "2.13.0"
+commons_cli = "1.5.0"
+commons_lang3 = "3.13.0"
+commons_text = "1.10.0"
+guava = "32.0.1-jre"
+junit = "4.13.2"
+proguard = "7.3.2"
+shadow = "8.1.1"
+smali = "3.0.3"
+xmlpull = "1.1.4c"
+xmlunit = "2.9.1"
+
+[libraries]
+baksmali = { module = "com.android.tools.smali:smali-baksmali", version.ref = "baksmali" }
+commons_cli = { module = "commons-cli:commons-cli", version.ref = "commons_cli"}
+commons_io = { module = "commons-io:commons-io", version.ref = "commons_io" }
+commons_lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons_lang3" }
+commons_text = { module = "org.apache.commons:commons-text", version.ref = "commons_text" }
+guava = { module = "com.google.guava:guava", version.ref = "guava" }
+junit = { module = "junit:junit", version.ref = "junit" }
+proguard = { module = "com.guardsquare:proguard-gradle", version.ref = "proguard" }
+smali = { module = "com.android.tools.smali:smali", version.ref = "smali" }
+xmlpull = { module = "xpp3:xpp3", version.ref = "xmlpull" }
+xmlunit = { module = "org.xmlunit:xmlunit-legacy", version.ref = "xmlunit" }
+
+[plugins]
+shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,8 @@
 rootProject.name = "apktool-cli"
 include("brut.j.common", "brut.j.util", "brut.j.dir", "brut.apktool:apktool-lib", "brut.apktool:apktool-cli")
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {}
+    }
+}


### PR DESCRIPTION
This migrates our Kotlin gradle scripts to leverage: https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format

This should allow Dependabot to help out again as well as making it clear where our dependency versions are declared.