### PR TITLE
fix: support more resource-modes params

### DIFF
--- a/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
+++ b/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
@@ -167,11 +167,15 @@ public class Main {
         if (cli.hasOption("m") || cli.hasOption("match-original")) {
             config.analysisMode = true;
         }
-        if (cli.hasOption("res-mode") || cli.hasOption("resolve-resources-mode")) {
-            String mode = cli.getOptionValue("res-mode");
+        if (cli.hasOption("resm") || cli.hasOption("res-mode") || cli.hasOption("resolve-resources-mode")) {
+            String mode = cli.getOptionValue("resm");
+            if (mode == null) {
+                mode = cli.getOptionValue("res-mode");
+            }
             if (mode == null) {
                 mode = cli.getOptionValue("resolve-resources-mode");
             }
+
             switch (mode) {
                 case "remove":
                 case "delete":


### PR DESCRIPTION
We will support:

 * `resm`
 * `res-mode`
 * `resolve-resources-mode`