### PR TITLE
build: add dependency graph support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,7 @@ jobs:
       - name: Build
         uses: gradle/gradle-build-action@v2.8.0
         with:
+          dependency-graph: generate-and-submit
           arguments: build shadowJar proguard
       - name: Upload
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This will add support for Dependency Graph uploading - https://github.com/marketplace/actions/gradle-build-action#github-dependency-graph-support

This will allow GitHub to know exact dependencies used, aiding to an easier process with Dependabot and license violation checks, etc.