### PR TITLE
Added auto-build of docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,7 +38,7 @@ jobs:
         run: echo "GITHUB_HASH=$(echo $GITHUB_SHA | cut -c 1-6)" >> $GITHUB_ENV
       - name: Get release tag
         id: tag
-        run: echo "GITHUB_TAG=$(echo ${GITHUB_REF:-no-tag})" >> $GITHUB_ENV
+        run: echo "GITHUB_TAG=$(echo ${GITHUB_REF:-no-tag} |sed 's|refs/tags/||g')" >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,16 +26,19 @@ jobs:
       packages: write
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Get Hash
+      - name: Get hash
         id: hash
         run: echo "GITHUB_HASH=$(echo $GITHUB_SHA | cut -c 1-6)" >> $GITHUB_ENV
+      - name: Get release tag
+        id: tag
+        run: echo "GITHUB_TAG=$(echo ${GITHUB_REF:-no-tag})" >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -47,4 +50,4 @@ jobs:
           platforms: linux/arm64/v8
           file: ./docker/dockerfiles/seed.Dockerfile
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.GITHUB_HASH }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.GITHUB_HASH }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.GITHUB_TAG }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,7 +47,10 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: linux/arm64/v8
-          file: ./docker/dockerfiles/seed.Dockerfile
+          platforms: linux/amd64
+          file: ./Dockerfile
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.GITHUB_HASH }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.GITHUB_TAG }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          tags: |
+          ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.GITHUB_HASH }}
+          ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.GITHUB_TAG }}
+          ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,50 @@
+name: Build and push docker
+
+on:
+  release:
+    types: [published]
+
+# Use the below to integrate into a Beta build from master
+# Changes to the Dockerfile to use the manually built Jar
+# from the build automation would be required.
+# on:
+#   pull_request:
+#     branches: [master]
+#     types: [closed]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+
+  build_and_push:
+    name: Build and push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get Hash
+        id: hash
+        run: echo "GITHUB_HASH=$(echo $GITHUB_SHA | cut -c 1-6)" >> $GITHUB_ENV
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2        
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/arm64/v8
+          file: ./docker/dockerfiles/seed.Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.GITHUB_HASH }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,8 +25,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Check out the repo
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
@@ -35,12 +34,10 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Get hash
         id: hash
-        run: echo "GITHUB_HASH=$(echo $GITHUB_SHA | cut -c 1-6)" >> $GITHUB_ENV
+        run: echo "APKTOOL_HASH=$(echo $GITHUB_SHA | cut -c 1-6)" >> $GITHUB_ENV
       - name: Get release tag
         id: tag
-        run: echo "GITHUB_TAG=$(echo ${GITHUB_REF:-no-tag} |sed 's|refs/tags/||g')" >> $GITHUB_ENV
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        run: echo "APKTOOL_TAG=$(echo ${GITHUB_REF:-no-tag} |sed 's|refs/tags/||g')" >> $GITHUB_ENV
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2        
       - name: Build and push Docker image
@@ -51,6 +48,6 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-          ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.GITHUB_HASH }}
-          ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.GITHUB_TAG }}
-          ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.APKTOOL_HASH }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.APKTOOL_TAG }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -2,8 +2,10 @@
 We provide an easy way to leverage `apktool`, along with common Android tools such as `zipalign` and `apksigner`, all from within Docker.
 
 ## Building the Docker image
-To build the image, use the included Dockerfile:
+To use the image, pull or build with the included Dockerfile:
 ```bash
+docker pull ghcr.io/ibotpeaches/apktool:latest
+# OR
 docker build -t apktool:latest .
 ```
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -6,15 +6,15 @@ To use the image, pull or build with the included Dockerfile:
 ```bash
 docker pull ghcr.io/ibotpeaches/apktool:latest
 # OR
-docker build -t apktool:latest .
+docker build -t apktool:local .
 ```
 
 ## Using the Docker image
-The best way to use the image is to create aliases to run the internal commands:
+The best way to use the image is to create aliases to run the internal commands. Replace `ghcr.io/ibotpeaches/apktool:latest` with `apktool:local` if you have built the image locally.
 ```bash
-alias apktool="docker run --rm -ti --name=apktool -v \"${PWD}:${PWD}\" -w \"${PWD}\" apktool:latest apktool"
-alias zipalign="docker run --rm -ti --name=zipalign -v \"${PWD}:${PWD}\" -w \"${PWD}\" apktool:latest zipalign"
-alias apksigner="docker run --rm -ti --name=apksigner -v \"${PWD}:${PWD}\" -w \"${PWD}\" apktool:latest apksigner"
+alias apktool="docker run --rm -ti --name=apktool -v \"${PWD}:${PWD}\" -w \"${PWD}\" ghcr.io/ibotpeaches/apktool:latest apktool"
+alias zipalign="docker run --rm -ti --name=zipalign -v \"${PWD}:${PWD}\" -w \"${PWD}\" ghcr.io/ibotpeaches/apktool:latest zipalign"
+alias apksigner="docker run --rm -ti --name=apksigner -v \"${PWD}:${PWD}\" -w \"${PWD}\" ghcr.io/ibotpeaches/apktool:latest apksigner"
 ```
 
 ## Running the commands


### PR DESCRIPTION
- Workflow for building `:<hash>` and `:latest` images and pushing to `ghcr.io` on release
- Updated instructions for `pull`
- Could consider updating to use the locally built JAR in the `build.yml` and including a `:beta` release on PRs into `master` in the future

**NOTE:** I have no real way to test this when integrated into the repo. It is modeled after successful local builds.