### PR TITLE
Move aapt2 to default (from aapt1)

### DIFF
--- a/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
+++ b/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
@@ -267,11 +267,13 @@ public class Main {
         if (cli.hasOption("nc") || cli.hasOption("no-crunch")) {
             config.noCrunch = true;
         }
+        if (cli.hasOption("use-aapt1")) {
+            config.useAapt2 = false;
+        }
 
-        // Temporary flag to enable the use of aapt2. This will transform in time to a use-aapt1 flag, which will be
-        // legacy and eventually removed.
-        if (cli.hasOption("use-aapt2")) {
-            config.useAapt2 = true;
+        if (cli.hasOption("use-aapt1") && cli.hasOption("use-aapt2")) {
+            System.err.println("You can only use one of --use-aapt1 or --use-aapt2.");
+            System.exit(1);
         }
 
         File outFile;
@@ -449,9 +451,14 @@ public class Main {
                 .desc("Load aapt from specified location.")
                 .build();
 
+        Option aapt1Option = Option.builder()
+            .longOpt("use-aapt1")
+            .desc("Use aapt binary instead of aapt2 during the build step.")
+            .build();
+
         Option aapt2Option = Option.builder()
                 .longOpt("use-aapt2")
-                .desc("Use aapt2 binary instead of aapt1 during the build step.")
+                .desc("Use aapt2 binary instead of aapt during the build step.")
                 .build();
 
         Option originalOption = Option.builder("c")
@@ -509,7 +516,7 @@ public class Main {
             buildOptions.addOption(netSecConfOption);
             buildOptions.addOption(aaptOption);
             buildOptions.addOption(originalOption);
-            buildOptions.addOption(aapt2Option);
+            buildOptions.addOption(aapt1Option);
             buildOptions.addOption(noCrunchOption);
         }
 
@@ -568,6 +575,7 @@ public class Main {
         allOptions.addOption(originalOption);
         allOptions.addOption(verboseOption);
         allOptions.addOption(quietOption);
+        allOptions.addOption(aapt1Option);
         allOptions.addOption(aapt2Option);
         allOptions.addOption(noCrunchOption);
         allOptions.addOption(onlyMainClassesOption);

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/Config.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/Config.java
@@ -51,7 +51,7 @@ public class Config {
     public boolean verbose = false;
     public boolean copyOriginalFiles = false;
     public boolean updateFiles = false;
-    public boolean useAapt2 = false;
+    public boolean useAapt2 = true;
     public boolean noCrunch = false;
     public int forceApi = 0;
 

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/AndroidOreoNotSparseTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/AndroidOreoNotSparseTest.java
@@ -47,6 +47,7 @@ public class AndroidOreoNotSparseTest extends BaseTest {
 
         LOGGER.info("Building not_sparse.apk...");
         Config config = Config.getDefaultConfig();
+        config.useAapt2 = false;
         new ApkBuilder(config, sTestNewDir).build(testApk);
     }
 

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/AndroidOreoSparseTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/AndroidOreoSparseTest.java
@@ -47,6 +47,7 @@ public class AndroidOreoSparseTest extends BaseTest {
 
         LOGGER.info("Building sparse.apk...");
         Config config = Config.getDefaultConfig();
+        config.useAapt2 = false;
         new ApkBuilder(config, sTestNewDir).build(testApk);
     }
 

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/BuildAndDecodeJarTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/BuildAndDecodeJarTest.java
@@ -16,10 +16,7 @@
  */
 package brut.androlib.aapt1;
 
-import brut.androlib.ApkBuilder;
-import brut.androlib.ApkDecoder;
-import brut.androlib.BaseTest;
-import brut.androlib.TestUtils;
+import brut.androlib.*;
 import brut.directory.ExtFile;
 import brut.common.BrutException;
 import brut.util.OS;
@@ -44,7 +41,9 @@ public class BuildAndDecodeJarTest extends BaseTest {
 
         LOGGER.info("Building testjar.jar...");
         File testJar = new File(sTmpDir, "testjar.jar");
-        new ApkBuilder(sTestOrigDir).build(testJar);
+        Config config = Config.getDefaultConfig();
+        config.useAapt2 = false;
+        new ApkBuilder(config, sTestOrigDir).build(testJar);
 
         LOGGER.info("Decoding testjar.jar...");
         ApkDecoder apkDecoder = new ApkDecoder(testJar);

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/BuildAndDecodeTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/BuildAndDecodeTest.java
@@ -16,10 +16,7 @@
  */
 package brut.androlib.aapt1;
 
-import brut.androlib.ApkBuilder;
-import brut.androlib.ApkDecoder;
-import brut.androlib.BaseTest;
-import brut.androlib.TestUtils;
+import brut.androlib.*;
 import brut.androlib.apk.ApkInfo;
 import brut.common.BrutException;
 import brut.directory.ExtFile;
@@ -52,7 +49,9 @@ public class BuildAndDecodeTest extends BaseTest {
 
         LOGGER.info("Building testapp.apk...");
         File testApk = new File(sTmpDir, "testapp.apk");
-        new ApkBuilder(sTestOrigDir).build(testApk);
+        Config config = Config.getDefaultConfig();
+        config.useAapt2 = false;
+        new ApkBuilder(config, sTestOrigDir).build(testApk);
 
         LOGGER.info("Decoding testapp.apk...");
         ApkDecoder apkDecoder = new ApkDecoder(testApk);

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/DebugTagRetainedTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/DebugTagRetainedTest.java
@@ -48,6 +48,7 @@ public class DebugTagRetainedTest extends BaseTest {
 
         LOGGER.info("Building issue1235.apk...");
         Config config = Config.getDefaultConfig();
+        config.useAapt2 = false;
         config.debugMode = true;
 
         File testApk = new File(sTmpDir, "issue1235.apk");

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/DefaultBaksmaliVariableTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/DefaultBaksmaliVariableTest.java
@@ -16,10 +16,7 @@
  */
 package brut.androlib.aapt1;
 
-import brut.androlib.ApkBuilder;
-import brut.androlib.ApkDecoder;
-import brut.androlib.BaseTest;
-import brut.androlib.TestUtils;
+import brut.androlib.*;
 import brut.common.BrutException;
 import brut.directory.ExtFile;
 import brut.util.OS;
@@ -46,7 +43,9 @@ public class DefaultBaksmaliVariableTest extends BaseTest {
 
         LOGGER.info("Building issue1481.jar...");
         File testJar = new File(sTmpDir, "issue1481.jar");
-        new ApkBuilder(sTestOrigDir).build(testJar);
+        Config config = Config.getDefaultConfig();
+        config.useAapt2 = false;
+        new ApkBuilder(config, sTestOrigDir).build(testJar);
 
         LOGGER.info("Decoding issue1481.jar...");
         ApkDecoder apkDecoder = new ApkDecoder(testJar);

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/EmptyResourcesArscTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/EmptyResourcesArscTest.java
@@ -50,6 +50,7 @@ public class EmptyResourcesArscTest {
 
         LOGGER.info("Building issue1730.apk...");
         Config config = Config.getDefaultConfig();
+        config.useAapt2 = false;
         new ApkBuilder(config, sTestNewDir).build(testApk);
     }
 

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/ExternalEntityTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/ExternalEntityTest.java
@@ -14,12 +14,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package brut.androlib.decode;
+package brut.androlib.aapt1;
 
-import brut.androlib.ApkBuilder;
-import brut.androlib.ApkDecoder;
-import brut.androlib.BaseTest;
-import brut.androlib.TestUtils;
+import brut.androlib.*;
 import brut.directory.ExtFile;
 import brut.common.BrutException;
 import brut.util.OS;
@@ -43,7 +40,9 @@ public class ExternalEntityTest extends BaseTest {
 
         LOGGER.info("Building doctype.apk...");
         File testApk = new File(sTestOrigDir, "doctype.apk");
-        new ApkBuilder(sTestOrigDir).build(testApk);
+        Config config = Config.getDefaultConfig();
+        config.useAapt2 = false;
+        new ApkBuilder(config, sTestOrigDir).build(testApk);
 
         LOGGER.info("Decoding doctype.apk...");
         ApkDecoder apkDecoder = new ApkDecoder(testApk);

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/LargeIntsInManifestTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/LargeIntsInManifestTest.java
@@ -16,10 +16,7 @@
  */
 package brut.androlib.aapt1;
 
-import brut.androlib.ApkBuilder;
-import brut.androlib.ApkDecoder;
-import brut.androlib.BaseTest;
-import brut.androlib.TestUtils;
+import brut.androlib.*;
 import brut.directory.ExtFile;
 import brut.common.BrutException;
 import brut.util.OS;
@@ -54,8 +51,10 @@ public class LargeIntsInManifestTest extends BaseTest {
         apkDecoder.decode(outDir);
 
         // build issue767
+        Config config = Config.getDefaultConfig();
+        config.useAapt2 = false;
         ExtFile testApk = new ExtFile(sTmpDir, apk + ".out");
-        new ApkBuilder(testApk).build(null);
+        new ApkBuilder(config, testApk).build(null);
         String newApk = apk + ".out" + File.separator + "dist" + File.separator + apk;
 
         // decode issue767 again

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/ProviderAttributeTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/ProviderAttributeTest.java
@@ -16,10 +16,7 @@
  */
 package brut.androlib.aapt1;
 
-import brut.androlib.ApkBuilder;
-import brut.androlib.ApkDecoder;
-import brut.androlib.BaseTest;
-import brut.androlib.TestUtils;
+import brut.androlib.*;
 import brut.directory.ExtFile;
 import brut.common.BrutException;
 import brut.util.OS;
@@ -62,7 +59,9 @@ public class ProviderAttributeTest extends BaseTest {
 
         // build issue636
         ExtFile testApk = new ExtFile(sTmpDir, apk + ".out");
-        new ApkBuilder(testApk).build(null);
+        Config config = Config.getDefaultConfig();
+        config.useAapt2 = false;
+        new ApkBuilder(config, testApk).build(null);
         String newApk = apk + ".out" + File.separator + "dist" + File.separator + apk;
         assertTrue(fileExists(newApk));
 

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/SharedLibraryTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/SharedLibraryTest.java
@@ -81,6 +81,7 @@ public class SharedLibraryTest extends BaseTest {
         Config config = Config.getDefaultConfig();
         config.frameworkDirectory = sTmpDir.getAbsolutePath();
         config.frameworkTag = "shared";
+        config.useAapt2 = false;
 
         // install library/framework
         new Framework(config).installFramework(new File(sTmpDir + File.separator + library));

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/UnknownCompressionTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/UnknownCompressionTest.java
@@ -42,6 +42,7 @@ public class UnknownCompressionTest extends BaseTest {
         String apk = "deflated_unknowns.apk";
         Config config = Config.getDefaultConfig();
         config.frameworkDirectory = sTmpDir.getAbsolutePath();
+        config.useAapt2 = false;
 
         sTestOrigDir = new ExtFile(sTmpDir, apk);
 


### PR DESCRIPTION
fixes: #3368 

aapt2 is the default. You can opt back to aapt1 with `--use-aapt1`