### PR TITLE
use apiLevel instead of forceApi when building the apk

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkBuilder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkBuilder.java
@@ -208,7 +208,7 @@ public class ApkBuilder {
             LOGGER.info("Smaling " + folder + " folder into " + filename + "...");
             //noinspection ResultOfMethodCallIgnored
             dex.delete();
-            SmaliBuilder.build(smaliDir, dex, mConfig.forceApi > 0 ? mConfig.forceApi : mMinSdkVersion);
+            SmaliBuilder.build(smaliDir, dex, mConfig.apiLevel > 0 ? mConfig.apiLevel : mMinSdkVersion);
         }
         return true;
     }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/Config.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/Config.java
@@ -53,7 +53,6 @@ public class Config {
     public boolean updateFiles = false;
     public boolean useAapt2 = true;
     public boolean noCrunch = false;
-    public int forceApi = 0;
 
     // Decode options
     public short decodeSources = DECODE_SOURCES_SMALI;


### PR DESCRIPTION
The change in PR https://github.com/iBotPeaches/Apktool/pull/3100 made it so `forceApi` was not set anymore. However, the code to build an APK with a specific API level was not updated, causing issues where a newer API level is required.

This PR completely removes `forceApi` and uses the existing `apiLevel` config value.