### PR TITLE
feat: de-dupe attribute names during styles writing

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResValue.java
@@ -22,4 +22,8 @@ public class ResValue {
     public boolean shouldRemoveUnknownRes() {
         return Config.getInstance().isDecodeResolveModeRemoving();
     }
+
+    public boolean isAnalysisMode() {
+        return Config.getInstance().analysisMode;
+    }
 }


### PR DESCRIPTION
![image](https://github.com/iBotPeaches/Apktool/assets/611784/46a16ba9-7e62-47e6-aa27-50351645f405)

fixes: #3400 

---

We maintain a little set to dedupe attribute names. This can be disabled if analysis mode is enabled.