### PR TITLE
build: run the different actions in parallel

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkBuilder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkBuilder.java
@@ -16,6 +16,7 @@
  */
 package brut.androlib;
 
+import brut.androlib.build_actions.*;
 import brut.androlib.exceptions.AndrolibException;
 import brut.androlib.apk.ApkInfo;
 import brut.androlib.apk.UsesFramework;
@@ -50,68 +51,6 @@ import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
 public class ApkBuilder {
-    private abstract static class BuildAction {
-
-    }
-
-    private static final class BuildSourcesAction extends BuildAction {
-        private final String mFolder;
-        private final String mFileName;
-        private final boolean mBuildSmali;
-
-        public BuildSourcesAction(String folder, String fileName, boolean buildSmali) {
-            mFolder = folder;
-            mFileName = fileName;
-            mBuildSmali = buildSmali;
-        }
-
-        public String getFolder() {
-            return mFolder;
-        }
-
-        public String getFileName() {
-            return mFileName;
-        }
-
-        public boolean getBuildSmali() {
-            return mBuildSmali;
-        }
-    }
-
-    private static final class BuildManifestAndResourcesAction extends BuildAction {
-        private final File mManifest;
-        private final File mManifestOriginal;
-
-        public BuildManifestAndResourcesAction(File manifest, File manifestOriginal) {
-
-            this.mManifest = manifest;
-            this.mManifestOriginal = manifestOriginal;
-        }
-
-        public File getManifest() {
-            return mManifest;
-        }
-
-        public File getManifestOriginal() {
-            return mManifestOriginal;
-        }
-    }
-
-    private static final class BuildLibraryAction extends BuildAction {
-        private final String mFolder;
-
-        public BuildLibraryAction(String folder) {
-            mFolder = folder;
-        }
-
-        public String getFolder() {
-            return mFolder;
-        }
-    }
-
-    private static final class CopyOriginalFilesAction extends BuildAction {
-    }
-
     private final static Logger LOGGER = Logger.getLogger(ApkBuilder.class.getName());
 
     private final Config mConfig;
@@ -227,7 +166,7 @@ public class ApkBuilder {
             BuildManifestAndResourcesAction typedAction = (BuildManifestAndResourcesAction) buildAction;
             buildManifestFile(typedAction.getManifest(), typedAction.getManifestOriginal());
             buildResources();
-        } else if (buildAction instanceof  CopyOriginalFilesAction) {
+        } else if (buildAction instanceof CopyOriginalFilesAction) {
             buildCopyOriginalFiles();
         } else {
             throw new RuntimeException("Unknown build action");

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/build_actions/BuildAction.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/build_actions/BuildAction.java
@@ -1,0 +1,5 @@
+package brut.androlib.build_actions;
+
+public abstract class BuildAction {
+
+}

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/build_actions/BuildLibraryAction.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/build_actions/BuildLibraryAction.java
@@ -1,0 +1,15 @@
+package brut.androlib.build_actions;
+
+import brut.androlib.build_actions.BuildAction;
+
+public final class BuildLibraryAction extends BuildAction {
+    private final String mFolder;
+
+    public BuildLibraryAction(String folder) {
+        mFolder = folder;
+    }
+
+    public String getFolder() {
+        return mFolder;
+    }
+}

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/build_actions/BuildManifestAndResourcesAction.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/build_actions/BuildManifestAndResourcesAction.java
@@ -1,0 +1,24 @@
+package brut.androlib.build_actions;
+
+import brut.androlib.build_actions.BuildAction;
+
+import java.io.File;
+
+public final class BuildManifestAndResourcesAction extends BuildAction {
+    private final File mManifest;
+    private final File mManifestOriginal;
+
+    public BuildManifestAndResourcesAction(File manifest, File manifestOriginal) {
+
+        this.mManifest = manifest;
+        this.mManifestOriginal = manifestOriginal;
+    }
+
+    public File getManifest() {
+        return mManifest;
+    }
+
+    public File getManifestOriginal() {
+        return mManifestOriginal;
+    }
+}

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/build_actions/BuildSourcesAction.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/build_actions/BuildSourcesAction.java
@@ -1,0 +1,25 @@
+package brut.androlib.build_actions;
+
+public final class BuildSourcesAction extends BuildAction {
+    private final String mFolder;
+    private final String mFileName;
+    private final boolean mBuildSmali;
+
+    public BuildSourcesAction(String folder, String fileName, boolean buildSmali) {
+        mFolder = folder;
+        mFileName = fileName;
+        mBuildSmali = buildSmali;
+    }
+
+    public String getFolder() {
+        return mFolder;
+    }
+
+    public String getFileName() {
+        return mFileName;
+    }
+
+    public boolean getBuildSmali() {
+        return mBuildSmali;
+    }
+}

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/build_actions/CopyOriginalFilesAction.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/build_actions/CopyOriginalFilesAction.java
@@ -1,0 +1,6 @@
+package brut.androlib.build_actions;
+
+import brut.androlib.build_actions.BuildAction;
+
+public final class CopyOriginalFilesAction extends BuildAction {
+}


### PR DESCRIPTION
My target here is to make the `build` command a little faster by running all the build actions that create the apk content (smali, resources, copying files) in parallel.

Here is a before/after of the different threads and CPU profile as measured by IDEA Profiler:

![CleanShot 2023-10-27 at 16 58 02](https://github.com/iBotPeaches/Apktool/assets/131878/4186ba01-6560-4dd3-b01f-e4c30be32ac0)

![CleanShot 2023-10-27 at 16 58 20](https://github.com/iBotPeaches/Apktool/assets/131878/bac1dc69-41fe-4c74-9671-692c12b31109)

Notes:
* Doing the actions in parallel doesn't seem to collide in any of my tests and the output files seem pretty separate but maybe i'm missing something.
* I used parallelStream instead of the ExecutorService strategy [used in baksmali](https://github.com/google/smali/blob/main/third_party/baksmali/src/main/java/com/android/tools/smali/baksmali/Baksmali.java#L70) as it appeared simpler to me but I'm not very well versed in the Java ecosystem so this is very open to suggestions
* I've preserved `BrutException` by rethrowing instead of wrapping but i'm not sure that it is what should be done.