### PR TITLE
build: build zip archive in parallel and in one pass

### DIFF
--- a/brut.apktool/apktool-cli/build.gradle.kts
+++ b/brut.apktool/apktool-cli/build.gradle.kts
@@ -66,6 +66,9 @@ tasks.register<ProGuardTask>("proguard") {
     dontwarn("com.google.common.collect.**")
     dontwarn("com.google.common.util.**")
     dontwarn("javax.xml.xpath.**")
+    dontwarn("org.apache.commons.compress.harmony.**")
+    dontwarn("org.apache.commons.compress.compressors.**")
+    dontwarn("org.apache.commons.compress.archivers.**")
     dontnote("**")
 
     val outPath = "build/libs/apktool-$apktoolVersion.jar"

--- a/brut.apktool/apktool-lib/build.gradle.kts
+++ b/brut.apktool/apktool-lib/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation(libs.smali)
     implementation(libs.xmlpull)
     implementation(libs.guava)
+    implementation(libs.commons.compress)
     implementation(libs.commons.lang3)
     implementation(libs.commons.io)
     implementation(libs.commons.text)

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkBuilder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkBuilder.java
@@ -33,6 +33,8 @@ import brut.directory.ExtFile;
 import brut.directory.ZipUtils;
 import brut.util.BrutIO;
 import brut.util.OS;
+import org.apache.commons.compress.archivers.zip.*;
+import org.apache.commons.compress.parallel.InputStreamSupplier;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.xml.sax.SAXException;
@@ -44,9 +46,6 @@ import java.nio.file.Files;
 import java.util.*;
 import java.util.logging.Logger;
 import java.util.zip.CRC32;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
-import java.util.zip.ZipOutputStream;
 
 public class ApkBuilder {
     private final static Logger LOGGER = Logger.getLogger(ApkBuilder.class.getName());
@@ -101,12 +100,8 @@ public class ApkBuilder {
         buildManifestFile(manifest, manifestOriginal);
         buildResources();
         buildLibs();
-        buildCopyOriginalFiles();
-        buildApk(outFile);
 
-        // we must go after the Apk is built, and copy the files in via Zip
-        // this is because Aapt won't add files it doesn't know (ex unknown files)
-        buildUnknownFiles(outFile);
+        buildApk(outFile);
 
         // we copied the AndroidManifest.xml to AndroidManifest.xml.orig so we can edit it
         // lets restore the unedited one, to not change the original
@@ -427,89 +422,54 @@ public class ApkBuilder {
         }
     }
 
-    private void buildUnknownFiles(File outFile) throws AndrolibException {
-        if (mApkInfo.unknownFiles != null) {
-            LOGGER.info("Copying unknown files/dir...");
-
-            Map<String, String> files = mApkInfo.unknownFiles;
-            File tempFile = new File(outFile.getParent(), outFile.getName() + ".apktool_temp");
-            boolean renamed = outFile.renameTo(tempFile);
-            if (!renamed) {
-                throw new AndrolibException("Unable to rename temporary file");
-            }
-
-            try (
-                ZipFile inputFile = new ZipFile(tempFile);
-                ZipOutputStream actualOutput = new ZipOutputStream(Files.newOutputStream(outFile.toPath()))
-            ) {
-                copyExistingFiles(inputFile, actualOutput);
-                copyUnknownFiles(actualOutput, files);
-            } catch (IOException | BrutException ex) {
-                throw new AndrolibException(ex);
-            }
-
-            // Remove our temporary file.
-            //noinspection ResultOfMethodCallIgnored
-            tempFile.delete();
-        }
-    }
-
-    private void copyExistingFiles(ZipFile inputFile, ZipOutputStream outputFile) throws IOException {
-        // First, copy the contents from the existing outFile:
-        Enumeration<? extends ZipEntry> entries = inputFile.entries();
-        while (entries.hasMoreElements()) {
-            ZipEntry entry = new ZipEntry(entries.nextElement());
-
-            // We can't reuse the compressed size because it depends on compression sizes.
-            entry.setCompressedSize(-1);
-            outputFile.putNextEntry(entry);
-
-            // No need to create directory entries in the final apk
-            if (!entry.isDirectory()) {
-                BrutIO.copy(inputFile, outputFile, entry);
-            }
-
-            outputFile.closeEntry();
-        }
-    }
-
-    private void copyUnknownFiles(ZipOutputStream outputFile, Map<String, String> files)
-            throws BrutException, IOException {
+    private void copyUnknownFiles(ParallelScatterZipCreator zipCreator, Map<String, String> files)
+            throws BrutException {
         File unknownFileDir = new File(mApkDir, UNK_DIRNAME);
 
-        // loop through unknown files
-        for (Map.Entry<String,String> unknownFileInfo : files.entrySet()) {
-            File inputFile;
+        try {
+            // loop through unknown files
+            for (Map.Entry<String, String> unknownFileInfo : files.entrySet()) {
+                File inputFile;
 
-            try {
-                inputFile = new File(unknownFileDir, BrutIO.sanitizeUnknownFile(unknownFileDir, unknownFileInfo.getKey()));
-            } catch (RootUnknownFileException | InvalidUnknownFileException | TraversalUnknownFileException exception) {
-                LOGGER.warning(String.format("Skipping file %s (%s)", unknownFileInfo.getKey(), exception.getMessage()));
-                continue;
+                try {
+                    inputFile = new File(unknownFileDir, BrutIO.sanitizeUnknownFile(unknownFileDir, unknownFileInfo.getKey()));
+                } catch (RootUnknownFileException | InvalidUnknownFileException |
+                         TraversalUnknownFileException exception) {
+                    LOGGER.warning(String.format("Skipping file %s (%s)", unknownFileInfo.getKey(), exception.getMessage()));
+                    continue;
+                }
+
+                if (inputFile.isDirectory()) {
+                    continue;
+                }
+
+                ZipArchiveEntry newEntry = new ZipArchiveEntry(unknownFileInfo.getKey());
+                int method = Integer.parseInt(unknownFileInfo.getValue());
+                LOGGER.fine(String.format("Copying unknown file %s with method %d", unknownFileInfo.getKey(), method));
+                if (method == ZipArchiveEntry.STORED) {
+                    newEntry.setMethod(ZipArchiveEntry.STORED);
+                    newEntry.setSize(inputFile.length());
+                    newEntry.setCompressedSize(-1);
+                    BufferedInputStream unknownFile = new BufferedInputStream(Files.newInputStream(inputFile.toPath()));
+                    CRC32 crc = BrutIO.calculateCrc(unknownFile);
+                    newEntry.setCrc(crc.getValue());
+                    unknownFile.close();
+                } else {
+                    newEntry.setMethod(ZipArchiveEntry.DEFLATED);
+                }
+
+                InputStreamSupplier streamSupplier = () -> {
+                    try {
+                        return new FileInputStream(inputFile);
+                    } catch (FileNotFoundException e) {
+                        throw new RuntimeException(e);
+                    }
+                };
+
+                zipCreator.addArchiveEntry(newEntry, streamSupplier);
             }
-
-            if (inputFile.isDirectory()) {
-                continue;
-            }
-
-            ZipEntry newEntry = new ZipEntry(unknownFileInfo.getKey());
-            int method = Integer.parseInt(unknownFileInfo.getValue());
-            LOGGER.fine(String.format("Copying unknown file %s with method %d", unknownFileInfo.getKey(), method));
-            if (method == ZipEntry.STORED) {
-                newEntry.setMethod(ZipEntry.STORED);
-                newEntry.setSize(inputFile.length());
-                newEntry.setCompressedSize(-1);
-                BufferedInputStream unknownFile = new BufferedInputStream(Files.newInputStream(inputFile.toPath()));
-                CRC32 crc = BrutIO.calculateCrc(unknownFile);
-                newEntry.setCrc(crc.getValue());
-                unknownFile.close();
-            } else {
-                newEntry.setMethod(ZipEntry.DEFLATED);
-            }
-            outputFile.putNextEntry(newEntry);
-
-            BrutIO.copy(inputFile, outputFile);
-            outputFile.closeEntry();
+        }catch (IOException e){
+            throw new BrutException(e);
         }
     }
 
@@ -533,8 +493,10 @@ public class ApkBuilder {
     }
 
     private void zipPackage(File apkFile, File rawDir, File assetDir) throws AndrolibException {
+        Map<String, String> files = mApkInfo.unknownFiles;
+
         try {
-            ZipUtils.zipFolders(rawDir, apkFile, assetDir, mApkInfo.doNotCompress);
+            ZipUtils.zipFolders(rawDir, apkFile, assetDir, mApkInfo.doNotCompress, zipCreator -> copyUnknownFiles(zipCreator, files));
         } catch (IOException | BrutException ex) {
             throw new AndrolibException(ex);
         }

--- a/brut.j.dir/build.gradle.kts
+++ b/brut.j.dir/build.gradle.kts
@@ -2,4 +2,5 @@ dependencies {
   implementation(project(":brut.j.common"))
   implementation(project(":brut.j.util"))
   implementation(libs.commons.io)
+  implementation(libs.commons.compress)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 baksmali = "3.0.3"
 commons_io = "2.14.0"
 commons_cli = "1.5.0"
+commons_compress = "1.24.0"
 commons_lang3 = "3.13.0"
 commons_text = "1.10.0"
 guava = "32.0.1-jre"
@@ -16,6 +17,7 @@ xmlunit = "2.9.1"
 baksmali = { module = "com.android.tools.smali:smali-baksmali", version.ref = "baksmali" }
 commons_cli = { module = "commons-cli:commons-cli", version.ref = "commons_cli"}
 commons_io = { module = "commons-io:commons-io", version.ref = "commons_io" }
+commons_compress = { module = "org.apache.commons:commons-compress", version.ref = "commons_compress" }
 commons_lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons_lang3" }
 commons_text = { module = "org.apache.commons:commons-text", version.ref = "commons_text" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }


### PR DESCRIPTION
* Use the apache compress library to zip in parallel
* Avoid the temporary zip file and copy by adding the unknown files directly while building the apk

Notes:
* It changes the exception types if one of the file is removed while we're generating the apk
* It will conflict a bit with https://github.com/iBotPeaches/Apktool/pull/3410 i'll do the merge in one PR or the other if they are both accepted.