### PR TITLE
Adapt null resource to be treated as reference instead of empty string.

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResValueFactory.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResValueFactory.java
@@ -32,9 +32,7 @@ public class ResValueFactory {
     public ResScalarValue factory(int type, int value, String rawValue) throws AndrolibException {
         switch (type) {
             case TypedValue.TYPE_NULL:
-                if (value == TypedValue.DATA_NULL_UNDEFINED) { // Special case $empty as explicitly defined empty value
-                    return new ResStringValue(null, value);
-                } else if (value == TypedValue.DATA_NULL_EMPTY) {
+                if (value == TypedValue.DATA_NULL_EMPTY) {
                     return new ResEmptyValue(value, rawValue, type);
                 }
                 return new ResReferenceValue(mPackage, 0, null);

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/BuildAndDecodeTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/BuildAndDecodeTest.java
@@ -72,6 +72,11 @@ public class BuildAndDecodeTest extends BaseTest {
     }
 
     @Test
+    public void valuesColorsTest() throws BrutException {
+        compareValuesFiles("values/colors.xml");
+    }
+
+    @Test
     public void valuesStringsTest() throws BrutException {
         compareValuesFiles("values/strings.xml");
     }

--- a/brut.apktool/apktool-lib/src/test/resources/aapt2/testapp/res/values/colors.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/aapt2/testapp/res/values/colors.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="test_color1">#ff123456</color>
+    <color name="test_color2">@android:color/white</color>
+    <color name="test_color3">#00000000</color>
+    <color name="issue_3416">@null</color>
+</resources>


### PR DESCRIPTION
This now decodes into:

```xml
    <color name="green_light_gradient">#ff52cb8c</color>
    <color name="green_oc831f">@null</color>
    <color name="grey">#ffd0cecd</color>
```

Instead of either crashing or becoming an `<item>`

Fixes: #3416     