### PR TITLE
#3427 - Treat manifest warnings as warnings

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/AaptInvoker.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/AaptInvoker.java
@@ -178,6 +178,9 @@ public class AaptInvoker {
 
         cmd.add("--no-compile-sdk-metadata");
 
+        // #3427 - Ignore stricter parsing during aapt2
+        cmd.add("--warn-manifest-validation");
+
         if (mApkInfo.sparseResources) {
             cmd.add("--enable-sparse-encoding");
         }

--- a/brut.apktool/apktool-lib/src/test/resources/aapt2/testapp/AndroidManifest.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/aapt2/testapp/AndroidManifest.xml
@@ -6,6 +6,7 @@
                 android:name="android.accessibilityservice"
                 android:resource="@xml/accessibility_service_config" />
         </service>
+        <fragment android:name=".views.Issue3427"/>
         <meta-data name="test_int_as_string" value="\ 12345" />
         <meta-data name="test_int" value="12345" />
     </application>


### PR DESCRIPTION
```
// Whether validation errors should be treated only as warnings. If this is 'true', then an
// incorrect node will not result in an error, but only as a warning, and the parsing will
// continue.
bool warn_validation = false;
```

Missed this during aapt2 addition. We should have aapt2 in the least strict mode possible as we are rebuilding apps and shouldn't be binded by the latest in build-time enforcement from aapt2.

Fixes: #3427 