### PR TITLE
test: assert miui aapt1 patch exists

### DIFF
--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/BuildAndDecodeTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/BuildAndDecodeTest.java
@@ -140,6 +140,11 @@ public class BuildAndDecodeTest extends BaseTest {
     }
 
     @Test
+    public void miuiRegressionTest() throws BrutException {
+        compareValuesFiles("values-godzillaui/strings.xml");
+    }
+
+    @Test
     public void valuesStringsTest() throws BrutException {
         compareValuesFiles("values-mcc001/strings.xml");
     }

--- a/brut.apktool/apktool-lib/src/test/resources/aapt1/testapp/res/values-godzillaui/strings.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/aapt1/testapp/res/values-godzillaui/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="test1">test1</string>
+</resources>


### PR DESCRIPTION
Was reported that MIUI wasn't working again. This is a simple test to prove yes/no.