### PR TITLE
fix: properly handle stamp-cert-sha256

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
@@ -49,7 +49,7 @@ public class ApkDecoder {
     private final static String UNK_DIRNAME = "unknown";
     private final static String[] APK_STANDARD_ALL_FILENAMES = new String[] {
         "classes.dex", "AndroidManifest.xml", "resources.arsc", "res", "r", "R",
-        "lib", "libs", "assets", "META-INF", "kotlin" };
+        "lib", "libs", "assets", "META-INF", "kotlin", "stamp-cert-sha256" };
     private final static String[] APK_RESOURCES_FILENAMES = new String[] {
         "resources.arsc", "res", "r", "R" };
     private final static String[] APK_MANIFEST_FILENAMES = new String[] {


### PR DESCRIPTION
fixes: #3536

Properly handle `stamp-cert-sha256` file as known v3+ signature file. Don't treat as unknown.