### PR TITLE
feat: support aapt optimization

### DIFF
--- a/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
+++ b/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
@@ -270,6 +270,15 @@ public class Main {
         if (cli.hasOption("nc") || cli.hasOption("no-crunch")) {
             config.noCrunch = true;
         }
+        if (cli.hasOption("srp") || cli.hasOption("shorten-res-paths")) {
+            config.shortenResPaths = true;
+        }
+        if (cli.hasOption("ese") || cli.hasOption("enable-sparse-encoding")) {
+            config.enableSparseEncoding = true;
+        }
+        if (cli.hasOption("crn") || cli.hasOption("collapse-res-names")) {
+            config.collapseResNames = true;
+        }
         if (cli.hasOption("use-aapt1")) {
             config.useAapt2 = false;
         }
@@ -286,8 +295,8 @@ public class Main {
             outFile = null;
         }
 
-        if (config.netSecConf && !config.useAapt2) {
-            System.err.println("-n / --net-sec-conf is only supported with --use-aapt2.");
+        if ((config.netSecConf || config.shortenResPaths || config.enableSparseEncoding || config.collapseResNames) && !config.useAapt2) {
+            System.err.println("-n / --net-sec-conf, -srp / --shorten-res-paths, -ese / --enable-sparse-encoding, -crn / --collapse-res-names are only supported with --use-aapt2.");
             System.exit(1);
         }
 
@@ -481,6 +490,21 @@ public class Main {
                 .desc("Disable crunching of resource files during the build step.")
                 .build();
 
+        Option shortenResPathsOption = Option.builder("srp")
+                .longOpt("shorten-res-paths")
+                .desc("Shortens the paths of resources inside the APK.")
+                .build();
+
+        Option enableSparseEncodingOption = Option.builder("ese")
+                .longOpt("enable-sparse-encoding")
+                .desc("Enables encoding of sparse entries using a binary search tree. This option is useful for optimization of APK size but at the cost of resource retrieval performance.")
+                .build();
+
+        Option collapseResNamesOption = Option.builder("crn")
+                .longOpt("collapse-res-names")
+                .desc("Collapses resource names to a single value in the key string pool.")
+                .build();
+
         Option tagOption = Option.builder("t")
                 .longOpt("tag")
                 .desc("Tag frameworks using <tag>.")
@@ -530,6 +554,9 @@ public class Main {
             buildOptions.addOption(originalOption);
             buildOptions.addOption(aapt1Option);
             buildOptions.addOption(noCrunchOption);
+            buildOptions.addOption(shortenResPathsOption);
+            buildOptions.addOption(enableSparseEncodingOption);
+            buildOptions.addOption(collapseResNamesOption);
         }
 
         // add global options

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/AaptInvoker.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/AaptInvoker.java
@@ -23,6 +23,9 @@ import brut.util.AaptManager;
 import brut.util.OS;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.*;
 import java.util.logging.Logger;
 
@@ -242,6 +245,45 @@ public class AaptInvoker {
             LOGGER.fine(cmd.toString());
         } catch (BrutException ex) {
             throw new AndrolibException(ex);
+        }
+
+        if (mConfig.shortenResPaths || mConfig.enableSparseEncoding || mConfig.collapseResNames) {
+            Path inputFilePath = new File(apkFile.getParent(), apkFile.getName() + ".tmp").toPath();
+            Path apkFilePath = apkFile.toPath();
+            try {
+                Files.copy(apkFilePath, inputFilePath, StandardCopyOption.REPLACE_EXISTING);
+                Files.delete(apkFilePath);
+            } catch (IOException e) {
+                throw new AndrolibException(e);
+            }
+
+            cmd = new ArrayList<>(compileCommand);
+            cmd.add("optimize");
+
+            cmd.add("-o");
+            cmd.add(apkFilePath.toString());
+
+            if (mConfig.shortenResPaths) {
+                cmd.add("--shorten-resource-paths");
+            }
+
+            if (mConfig.enableSparseEncoding) {
+                cmd.add("--enable-sparse-encoding");
+            }
+
+            if (mConfig.collapseResNames) {
+                cmd.add("--collapse-resource-names");
+            }
+
+            cmd.add(inputFilePath.toString());
+
+            try {
+                OS.exec(cmd.toArray(new String[0]));
+                LOGGER.fine("aapt2 optimize command ran: ");
+                LOGGER.fine(cmd.toString());
+            } catch (BrutException ex) {
+                throw new AndrolibException(ex);
+            }
         }
     }
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/Config.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/Config.java
@@ -54,6 +54,12 @@ public class Config {
     public boolean useAapt2 = true;
     public boolean noCrunch = false;
 
+    // Optimize options, only supported by aapt2.
+    // see https://developer.android.com/tools/aapt2#optimize_options
+    public boolean shortenResPaths = false;
+    public boolean enableSparseEncoding = false;
+    public boolean collapseResNames = false;
+
     // Decode options
     public short decodeSources = DECODE_SOURCES_SMALI;
     public short decodeResources = DECODE_RESOURCES_FULL;


### PR DESCRIPTION
These options help reduce the apk size when using `aapt2`, and `--collapse-resource-names` may have side effects.