### PR TITLE
Reproducible Builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
       - analyze-windows-aapt
     name: Build/Test (JDK ${{ matrix.java }}, ${{ matrix.os }})
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
         java: [ 8, 11, 17, 21 ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
       - analyze-windows-aapt
     name: Build/Test (JDK ${{ matrix.java }}, ${{ matrix.os }})
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
         java: [ 8, 11, 17, 21 ]

--- a/brut.apktool/apktool-cli/build.gradle.kts
+++ b/brut.apktool/apktool-cli/build.gradle.kts
@@ -1,24 +1,15 @@
-import proguard.gradle.ProGuardTask
-
 val apktoolVersion: String by rootProject.extra
 
 plugins {
     application
 }
 
-// Buildscript is deprecated, but the alternative approach does not support expanded properties
-// https://github.com/gradle/gradle/issues/9830
-// So we must hard-code the version here.
-buildscript {
-    dependencies {
-        // Proguard doesn't support plugin DSL - https://github.com/Guardsquare/proguard/issues/225
-        classpath(libs.proguard)
-    }
-}
+val r8: Configuration by configurations.creating
 
 dependencies {
     implementation(libs.commons.cli)
     implementation(project(":brut.apktool:apktool-lib"))
+    r8(libs.r8)
 }
 
 application {
@@ -38,7 +29,7 @@ tasks.register<Delete>("cleanOutputDirectory") {
     })
 }
 
-tasks.create("shadowJar", Jar::class) {
+val shadowJar = tasks.create("shadowJar", Jar::class) {
     dependsOn("build")
     group = "build"
     description = "Creates a single executable JAR with all dependencies"
@@ -54,35 +45,24 @@ tasks.create("shadowJar", Jar::class) {
     with(tasks.jar.get())
 }
 
-tasks.register<ProGuardTask>("proguard") {
+tasks.register<JavaExec>("proguard") {
     dependsOn("shadowJar")
-    injars(tasks.named("shadowJar").get().outputs.files)
 
-    val javaHome = System.getProperty("java.home")
-    if (JavaVersion.current() <= JavaVersion.VERSION_1_8) {
-        libraryjars("$javaHome/lib/jce.jar")
-        libraryjars("$javaHome/lib/rt.jar")
-    } else {
-        libraryjars(mapOf("jarfilter" to "!**.jar", "filter" to "!module-info.class"),
-            {
-                "$javaHome/jmods/"
-            }
-        )
-    }
+    val proguardRules = file("proguard-rules.pro")
 
-    dontobfuscate()
-    dontoptimize()
+    inputs.files(shadowJar, proguardRules)
+    outputs.file("build/libs/apktool-$apktoolVersion.jar")
 
-    keep("class brut.apktool.Main { public static void main(java.lang.String[]); }")
-    keepclassmembers("enum * { public static **[] values(); public static ** valueOf(java.lang.String); }")
-    dontwarn("com.google.common.base.**")
-    dontwarn("com.google.common.collect.**")
-    dontwarn("com.google.common.util.**")
-    dontwarn("javax.xml.xpath.**")
-    dontnote("**")
+    classpath(r8)
+    mainClass.set("com.android.tools.r8.R8")
 
-    val outPath = "build/libs/apktool-$apktoolVersion.jar"
-    outjars(outPath)
+    args = mutableListOf(
+        "--release",
+        "--classfile",
+        "--lib", javaLauncher.get().metadata.installationPath.toString(),
+        "--output", "build/libs/apktool-$apktoolVersion.jar",
+        "--pg-conf", proguardRules.toString(),
+    )
 }
 
 tasks.getByPath(":release").dependsOn("proguard")

--- a/brut.apktool/apktool-cli/build.gradle.kts
+++ b/brut.apktool/apktool-cli/build.gradle.kts
@@ -63,6 +63,7 @@ tasks.register<JavaExec>("proguard") {
         "--release",
         "--classfile",
         "--no-minification",
+        "--map-diagnostics:UnusedProguardKeepRuleDiagnostic", "info", "none",
         "--lib", javaLauncher.get().metadata.installationPath.toString(),
         "--output", outputs.files.singleFile.toString(),
         "--pg-conf", proguardRules.toString(),

--- a/brut.apktool/apktool-cli/build.gradle.kts
+++ b/brut.apktool/apktool-cli/build.gradle.kts
@@ -3,7 +3,6 @@ import proguard.gradle.ProGuardTask
 val apktoolVersion: String by rootProject.extra
 
 plugins {
-    alias(libs.plugins.shadow)
     application
 }
 

--- a/brut.apktool/apktool-cli/build.gradle.kts
+++ b/brut.apktool/apktool-cli/build.gradle.kts
@@ -50,6 +50,10 @@ val shadowJar = tasks.create("shadowJar", Jar::class) {
 tasks.register<JavaExec>("proguard") {
     dependsOn("shadowJar")
 
+    onlyIf {
+        JavaVersion.current().isJava11Compatible
+    }
+
     val proguardRules = file("proguard-rules.pro")
     val originalJar = shadowJar.outputs.files.singleFile
 

--- a/brut.apktool/apktool-cli/proguard-rules.pro
+++ b/brut.apktool/apktool-cli/proguard-rules.pro
@@ -1,0 +1,7 @@
+-keep class brut.apktool.Main {
+    public static void main(java.lang.String[]);
+}
+-keepclassmembers enum * {
+    static **[] values();
+    static ** valueOf(java.lang.String);
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,7 +55,6 @@ if ("release" !in gradle.startParameter.taskNames) {
 }
 
 plugins {
-    alias(libs.plugins.shadow)
     `java-library`
     `maven-publish`
     signing

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ commons_lang3 = "3.14.0"
 commons_text = "1.11.0"
 guava = "32.0.1-jre"
 junit = "4.13.2"
-proguard = "7.4.2"
+r8 = "8.3.37"
 smali = "3.0.5"
 xmlpull = "1.1.4c"
 xmlunit = "2.9.1"
@@ -19,7 +19,7 @@ commons_lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "co
 commons_text = { module = "org.apache.commons:commons-text", version.ref = "commons_text" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 junit = { module = "junit:junit", version.ref = "junit" }
-proguard = { module = "com.guardsquare:proguard-gradle", version.ref = "proguard" }
+r8 = { module = "com.android.tools:r8", version.ref = "r8" }
 smali = { module = "com.android.tools.smali:smali", version.ref = "smali" }
 xmlpull = { module = "xpp3:xpp3", version.ref = "xmlpull" }
 xmlunit = { module = "org.xmlunit:xmlunit-legacy", version.ref = "xmlunit" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,6 @@ commons_text = "1.11.0"
 guava = "32.0.1-jre"
 junit = "4.13.2"
 proguard = "7.4.2"
-shadow = "8.1.1"
 smali = "3.0.5"
 xmlpull = "1.1.4c"
 xmlunit = "2.9.1"
@@ -24,6 +23,3 @@ proguard = { module = "com.guardsquare:proguard-gradle", version.ref = "proguard
 smali = { module = "com.android.tools.smali:smali", version.ref = "smali" }
 xmlpull = { module = "xpp3:xpp3", version.ref = "xmlpull" }
 xmlunit = { module = "org.xmlunit:xmlunit-legacy", version.ref = "xmlunit" }
-
-[plugins]
-shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow" }


### PR DESCRIPTION
In light of recent events - I'm working to prove the builds I make for Apktool are indeed reproducible by the community.

----

* [x] Drop ShadowJar for manual archive building.
* [x] Remove Proguard
* [x] Clean output folder prior to R8 Run.
* [x] Keep naming the same on `shadowJar` even though Plugin not used.
* [x] Keep naming the same on `proguard` even though its R8`
* [x] Investigate suppressing `Proguard rule does not match anything`
* [x] Investigate Java8 failure when R8 invoked (`java.lang.UnsupportedClassVersionError: com/android/tools/r8/R8 has been compiled by a more recent version of the Java Runtime`)
* [x] Confirm build is reproducible between 2 linux machines.
* [x] Confirm build is reproducible between 2 mac machines.
* [x] Confirm build is reproducible between 2 win machines.
* [x] Confirm build is reproducible between all 3 supported os.