### PR TITLE
Correct wording in CLI usage messages

### DIFF
--- a/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
+++ b/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
@@ -383,7 +383,7 @@ public class Main {
 
         Option analysisOption = Option.builder("m")
                 .longOpt("match-original")
-                .desc("Keep files to closest to original as possible (prevents rebuild).")
+                .desc("Keep files closest to original as possible (prevents rebuild).")
                 .build();
 
         Option apiLevelOption = Option.builder("api")
@@ -492,7 +492,7 @@ public class Main {
                 .longOpt("output")
                 .desc("The name of apk that gets written. (default: dist/name.apk)")
                 .hasArg(true)
-                .argName("dir")
+                .argName("file")
                 .build();
 
         Option outputDecOption = Option.builder("o")


### PR DESCRIPTION
Related but unsure if worth separate issues:

- Please add separators between different subcommands. It's really hard to see from the quick glance which options apply to, say, `decode`, especially since they all have different alignment (`if` aligned to 24 columns, `d` to 32, `b` to 25, etc.):

```
usage: apktool [-q|--quiet OR -v|--verbose] if|install-framework [options] <framework.apk>
 -p,--frame-path <dir>   Store framework files into <dir>.
 -t,--tag <tag>          Tag frameworks using <tag>.
*** Why not put a blank line here? ***
usage: apktool [-q|--quiet OR -v|--verbose] d[ecode] [options] <file_apk>
 -api,--api-level <API>         The numeric api-level of the file to generate, e.g. 14 for ICS.
 -b,--no-debug-info             Do not write out debug info (.local, .param, .line, etc.)
... lots of text ...
 -s,--no-src                    Do not decode sources.
 -t,--frame-tag <tag>           Use framework files tagged by <tag>.
*** Why not put a blank line here? ***
usage: apktool [-q|--quiet OR -v|--verbose] b[uild] [options] <app_path>
 -a,--aapt <loc>          Load aapt from specified location.
```

- `-c,--copy-original` says "See project page for more info" but I was unable to locate anything related to this option on apktool.org. I understand it might be self-explanatory, then why this reference to more info?
- `-nc,--no-crunch` says "Disable crunching of resource files" but this doesn't explain anything. A pointer on what this does would be much appreciated.

P.S: thank you for maintaining this project and making it strive for over a decade!