### PR TITLE
Resolve a resource leak where the ZipFile is not closed

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/Framework.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/Framework.java
@@ -52,8 +52,7 @@ public class Framework {
     public void installFramework(File frameFile, String tag) throws AndrolibException {
         InputStream in = null;
         ZipOutputStream out = null;
-        try {
-            ZipFile zip = new ZipFile(frameFile);
+        try(ZipFile zip = new ZipFile(frameFile)) {
             ZipEntry entry = zip.getEntry("resources.arsc");
 
             if (entry == null) {
@@ -98,7 +97,6 @@ public class Framework {
                 out.closeEntry();
             }
 
-            zip.close();
             LOGGER.info("Framework installed to: " + outFile);
         } catch (IOException ex) {
             throw new AndrolibException(ex);


### PR DESCRIPTION
If th zip entry for resources.arsc is not found an exception is thrown, but the ZipFile is not closed. Using try-with-resources means that the ZipFile will always be closed irrespective of how the code block exits.