### PR TITLE
Add missing stream closing

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/ResourcesDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/ResourcesDecoder.java
@@ -28,6 +28,7 @@ import brut.androlib.res.xml.ResXmlPatcher;
 import brut.directory.Directory;
 import brut.directory.DirectoryException;
 import brut.directory.FileDirectory;
+import org.apache.commons.io.IOUtils;
 import org.xmlpull.v1.XmlSerializer;
 
 import java.io.*;
@@ -95,8 +96,8 @@ public class ResourcesDecoder {
         } catch (DirectoryException ex) {
             throw new AndrolibException(ex);
         } finally {
-            closeQuietly(inputStream);
-            closeQuietly(outputStream);
+            IOUtils.closeQuietly(inputStream);
+            IOUtils.closeQuietly(outputStream);
         }
 
         if (mApkInfo.hasResources()) {
@@ -114,16 +115,6 @@ public class ResourcesDecoder {
 
                 // update apk info
                 mApkInfo.packageInfo.forcedPackageId = String.valueOf(mResTable.getPackageId());
-            }
-        }
-    }
-
-    private void closeQuietly(Closeable toClose) {
-        if (toClose != null) {
-            try {
-                toClose.close();
-            } catch (IOException e) {
-                LOGGER.warning(String.format("Can`t close: %s!!!", toClose));
             }
         }
     }


### PR DESCRIPTION
Noticed that when used as a library, you can't delete or rename the manifest file. This fix, should solve the problem.

Here is an example of an error that can happen.
![image](https://github.com/iBotPeaches/Apktool/assets/30636242/2571e745-7cc8-437b-9987-2494de2fab9a)
