### PR TITLE
Sort files list in FileDirectory::loadAll()

### DIFF
--- a/brut.j.dir/src/main/java/brut/directory/FileDirectory.java
+++ b/brut.j.dir/src/main/java/brut/directory/FileDirectory.java
@@ -18,6 +18,8 @@ package brut.directory;
 
 import java.io.*;
 import java.net.URLDecoder;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 
@@ -107,6 +109,8 @@ public class FileDirectory extends AbstractDirectory {
         mDirs = new LinkedHashMap<>();
 
         File[] files = getDir().listFiles();
+        Arrays.sort(files, Comparator.comparing(f -> f.getName()));
+
         for (File file : files) {
             if (file.isFile()) {
                 mFiles.add(file.getName());


### PR DESCRIPTION
This lets us assemble classes.dex in a reproducible manner.

Test:
  apktool d test.apk > /dev/null
  apktool b test > /dev/null
  sha1sum test/build/apk/classes.dex
  apktool -f d test.apk > /dev/null
  apktool b test > /dev/null
  sha1sum test/build/apk/classes.dex