### PR TITLE
fix: allow maven to publish without implicit task ordering

### DIFF
--- a/brut.apktool/apktool-cli/build.gradle.kts
+++ b/brut.apktool/apktool-cli/build.gradle.kts
@@ -25,6 +25,8 @@ tasks.withType<AbstractArchiveTask>().configureEach {
 
 tasks.register<Delete>("cleanOutputDirectory") {
     delete(fileTree("build/libs") {
+        exclude("apktool-cli-sources.jar")
+        exclude("apktool-cli-javadoc.jar")
         exclude("apktool-cli-all.jar")
     })
 }
@@ -73,4 +75,16 @@ tasks.register<JavaExec>("proguard") {
         "--pg-conf", proguardRules.toString(),
         originalJar.toString()
     )
+}
+
+tasks.withType<org.gradle.api.publish.maven.tasks.PublishToMavenRepository> {
+    dependsOn(tasks.named("shadowJar"))
+}
+
+tasks.withType<org.gradle.plugins.signing.Sign> {
+    dependsOn(tasks.named("shadowJar"))
+}
+
+tasks.withType<org.gradle.api.publish.tasks.GenerateModuleMetadata> {
+    dependsOn(tasks.named("shadowJar"))
 }


### PR DESCRIPTION
This fixes 2 things.

```
A problem was found with the configuration of task ':brut.apktool:apktool-cli:shadowJar' (type 'Jar').
  - Gradle detected a problem with the following location: 'Apktool/brut.apktool/apktool-cli/build/libs/apktool-cli.jar'.
    
    Reason: Task ':brut.apktool:apktool-cli:generateMetadataFileForMavenJavaPublication' uses this output of task ':brut.apktool:apktool-cli:shadowJar' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
```

```
Execution failed for task ':brut.apktool:apktool-cli:generateMetadataFileForMavenJavaPublication'.
> java.io.FileNotFoundException: Apktool/brut.apktool/apktool-cli/build/libs/apktool-cli-javadoc.jar (No such file or directory)
```

---

* Adapted with some ugly verbose config to depend Maven tasks on the completion of shadowJar
* Ensured the clean build directory doesn't purge sources/javadoc (which is only apparent on maven publish)