### PR TITLE
new: featureFlags support for SDK 35 apps

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/AaptInvoker.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/AaptInvoker.java
@@ -189,6 +189,15 @@ public class AaptInvoker {
             cmd.add("-x");
         }
 
+        if (!mApkInfo.featureFlags.isEmpty()) {
+            List<String> featureFlags = new ArrayList<>();
+            for (Map.Entry<String, Boolean> entry : mApkInfo.featureFlags.entrySet()) {
+                featureFlags.add(entry.getKey() + "=" + entry.getValue());
+            }
+            cmd.add("--feature-flags");
+            cmd.add(String.join(",", featureFlags));
+        }
+
         if (include != null) {
             for (File file : include) {
                 cmd.add("-I");

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
@@ -21,6 +21,7 @@ import brut.androlib.exceptions.InFileNotFoundException;
 import brut.androlib.exceptions.OutDirExistsException;
 import brut.androlib.apk.ApkInfo;
 import brut.androlib.res.ResourcesDecoder;
+import brut.androlib.res.xml.ResXmlPatcher;
 import brut.androlib.src.SmaliDecoder;
 import brut.directory.Directory;
 import brut.directory.ExtFile;
@@ -319,6 +320,15 @@ public class ApkDecoder {
         // in case we have no resources, we should store the minSdk we pulled from the source opcode api level
         if (!mApkInfo.hasResources() && mMinSdkVersion > 0) {
             mApkInfo.setMinSdkVersion(Integer.toString(mMinSdkVersion));
+        }
+
+        // record feature flags
+        File manifest = new File(outDir, "AndroidManifest.xml");
+        List<String> featureFlags = ResXmlPatcher.pullManifestFeatureFlags(manifest);
+        if (featureFlags != null) {
+            for (String flag : featureFlags) {
+                mApkInfo.addFeatureFlag(flag, true);
+            }
         }
 
         // record uncompressed files

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/apk/ApkInfo.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/apk/ApkInfo.java
@@ -48,6 +48,7 @@ public class ApkInfo implements YamlSerializable {
     public Map<String, String> sdkInfo = new LinkedHashMap<>();
     public PackageInfo packageInfo = new PackageInfo();
     public VersionInfo versionInfo = new VersionInfo();
+    public Map<String, Boolean> featureFlags = new LinkedHashMap<>();
     public boolean sharedLibrary;
     public boolean sparseResources;
     public List<String> doNotCompress = new ArrayList<>();
@@ -185,6 +186,10 @@ public class ApkInfo implements YamlSerializable {
         }
     }
 
+    public void addFeatureFlag(String flag, boolean value) {
+        featureFlags.put(flag, value);
+    }
+
     public void save(File file) throws AndrolibException {
         try (YamlWriter writer = new YamlWriter(new FileOutputStream(file))) {
             write(writer);
@@ -235,7 +240,7 @@ public class ApkInfo implements YamlSerializable {
             }
             case "sdkInfo": {
                 sdkInfo.clear();
-                reader.readMap(sdkInfo);
+                reader.readStringMap(sdkInfo);
                 break;
             }
             case "packageInfo": {
@@ -246,6 +251,11 @@ public class ApkInfo implements YamlSerializable {
             case "versionInfo": {
                 versionInfo = new VersionInfo();
                 reader.readObject(versionInfo);
+                break;
+            }
+            case "featureFlags": {
+                featureFlags.clear();
+                reader.readBoolMap(featureFlags);
                 break;
             }
             case "sharedLibrary": {
@@ -270,9 +280,12 @@ public class ApkInfo implements YamlSerializable {
         writer.writeString("apkFileName", apkFileName);
         writer.writeBool("isFrameworkApk", isFrameworkApk);
         writer.writeObject("usesFramework", usesFramework);
-        writer.writeStringMap("sdkInfo", sdkInfo);
+        writer.writeMap("sdkInfo", sdkInfo);
         writer.writeObject("packageInfo", packageInfo);
         writer.writeObject("versionInfo", versionInfo);
+        if (!featureFlags.isEmpty()) {
+            writer.writeMap("featureFlags", featureFlags);
+        }
         writer.writeBool("sharedLibrary", sharedLibrary);
         writer.writeBool("sparseResources", sparseResources);
         if (!doNotCompress.isEmpty()) {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/apk/YamlReader.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/apk/YamlReader.java
@@ -203,12 +203,21 @@ public class YamlReader {
         readList(list, (items, reader) -> items.add(reader.getLine().getValueInt()));
     }
 
-    public void readMap(Map<String, String> map) throws AndrolibException {
+    public void readStringMap(Map<String, String> map) throws AndrolibException {
         readObject(map,
             line -> line.hasColon,
             (items, reader) -> {
                 YamlLine line = reader.getLine();
                 items.put(line.getKey(), line.getValue());
+            });
+    }
+
+    public void readBoolMap(Map<String, Boolean> map) throws AndrolibException {
+        readObject(map,
+            line -> line.hasColon,
+            (items, reader) -> {
+                YamlLine line = reader.getLine();
+                items.put(line.getKey(), line.getValueBool());
             });
     }
 }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/apk/YamlWriter.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/apk/YamlWriter.java
@@ -95,7 +95,7 @@ public class YamlWriter implements Closeable {
         }
     }
 
-    public void writeStringMap(String key, Map<String, String> map) {
+    public <T> void writeMap(String key, Map<String, T> map) {
         if (Objects.isNull(map)) {
             return;
         }
@@ -103,7 +103,7 @@ public class YamlWriter implements Closeable {
         mWriter.println(escape(key) + ":");
         nextIndent();
         for (String mapKey : map.keySet()) {
-            writeString(mapKey, map.get(mapKey));
+            writeString(mapKey, String.valueOf(map.get(mapKey)));
         }
         prevIndent();
     }

--- a/brut.apktool/apktool-lib/src/test/resources/aapt2/testapp/AndroidManifest.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/aapt2/testapp/AndroidManifest.xml
@@ -11,4 +11,5 @@
         <meta-data name="test_int" value="12345" />
     </application>
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
+    <permission android:featureFlag="brut.feature.flag" android:label="Test Permission" android:name="brut.permission.TEST" android:permissionGroup="android.permission-group.UNDEFINED" android:protectionLevel="signature"/>
 </manifest>

--- a/brut.apktool/apktool-lib/src/test/resources/aapt2/testapp/apktool.yml
+++ b/brut.apktool/apktool-lib/src/test/resources/aapt2/testapp/apktool.yml
@@ -9,6 +9,8 @@ packageInfo:
 versionInfo:
   versionCode: '1'
   versionName: '1.0'
+featureFlags:
+  brut.feature.flag: true
 doNotCompress:
 - assets/0byte_file.jpg
 sparseResources: false


### PR DESCRIPTION
This records all featureFlag attrs that were enabled when the APK was originally built. This is now required by AAPT2 to pass these flags and their enabled/disabled state if they are used in AndroidManifest.xml.
The flags are recorded to apktool.yml and can be configured, if so desired. In normal usage, all flags should remain set to true (i.e. enabled). Sample APK sourced from AOSP Android 15.

[https://drive.google.com/file/d/1av7Ih7-YUXi73Hf0E3xlPv-V-nE_sXdt/view](https://drive.google.com/file/d/1av7Ih7-YUXi73Hf0E3xlPv-V-nE_sXdt/view)