### PR TITLE
fix: avoid trying to parse raw AndroidManifest

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
@@ -21,7 +21,6 @@ import brut.androlib.exceptions.InFileNotFoundException;
 import brut.androlib.exceptions.OutDirExistsException;
 import brut.androlib.apk.ApkInfo;
 import brut.androlib.res.ResourcesDecoder;
-import brut.androlib.res.xml.ResXmlPatcher;
 import brut.androlib.src.SmaliDecoder;
 import brut.directory.Directory;
 import brut.directory.ExtFile;
@@ -320,15 +319,6 @@ public class ApkDecoder {
         // in case we have no resources, we should store the minSdk we pulled from the source opcode api level
         if (!mApkInfo.hasResources() && mMinSdkVersion > 0) {
             mApkInfo.setMinSdkVersion(Integer.toString(mMinSdkVersion));
-        }
-
-        // record feature flags
-        File manifest = new File(outDir, "AndroidManifest.xml");
-        List<String> featureFlags = ResXmlPatcher.pullManifestFeatureFlags(manifest);
-        if (featureFlags != null) {
-            for (String flag : featureFlags) {
-                mApkInfo.addFeatureFlag(flag, true);
-            }
         }
 
         // record uncompressed files

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/apk/ApkInfo.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/apk/ApkInfo.java
@@ -24,6 +24,7 @@ import brut.directory.ExtFile;
 import brut.directory.FileDirectory;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -192,7 +193,10 @@ public class ApkInfo implements YamlSerializable {
     }
 
     public void save(File file) throws AndrolibException {
-        try (YamlWriter writer = new YamlWriter(new FileOutputStream(file))) {
+        try (
+            OutputStream out = Files.newOutputStream(file.toPath());
+            YamlWriter writer = new YamlWriter(out)
+        ) {
             write(writer);
         } catch (FileNotFoundException ex) {
             throw new AndrolibException("File not found");

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResTable.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/ResTable.java
@@ -260,16 +260,10 @@ public class ResTable {
     }
 
     public void setSparseResources(boolean flag) {
-        if (mApkInfo.sparseResources != flag) {
-            LOGGER.info("Sparsely packed resources detected.");
-        }
         mApkInfo.sparseResources = flag;
     }
 
     public void setCompactEntries(boolean flag) {
-        if (mApkInfo.compactEntries != flag) {
-            LOGGER.info("Compactly packed resource entries detected.");
-        }
         mApkInfo.compactEntries = flag;
     }
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
@@ -501,8 +501,8 @@ public class ARSCDecoder {
         char[] language = new char[0];
         char[] country = new char[0];
         if (size >= 12) {
-            language = this.unpackLanguageOrRegion(mIn.readByte(), mIn.readByte(), 'a');
-            country = this.unpackLanguageOrRegion(mIn.readByte(), mIn.readByte(), '0');
+            language = unpackLanguageOrRegion(mIn.readByte(), mIn.readByte(), 'a');
+            country = unpackLanguageOrRegion(mIn.readByte(), mIn.readByte(), '0');
             read = 12;
         }
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResFileDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ResFileDecoder.java
@@ -36,7 +36,7 @@ public class ResFileDecoder {
     private final ResStreamDecoderContainer mDecoders;
 
     public ResFileDecoder(ResStreamDecoderContainer decoders) {
-        this.mDecoders = decoders;
+        mDecoders = decoders;
     }
 
     public void decode(ResResource res, Directory inDir, Directory outDir, Map<String, String> resFileMapping)

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StyledString.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/StyledString.java
@@ -31,8 +31,8 @@ public class StyledString {
     private final List<Span> mSpans;
 
     public StyledString(String text, List<Span> spans) {
-        this.mText = text;
-        this.mSpans = spans;
+        mText = text;
+        mSpans = spans;
     }
 
     String getText() {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResXmlPatcher.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResXmlPatcher.java
@@ -20,6 +20,7 @@ import brut.androlib.exceptions.AndrolibException;
 import org.w3c.dom.*;
 import org.xml.sax.SAXException;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -29,10 +30,14 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-import javax.xml.xpath.*;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.io.*;
 import java.util.*;
 import java.util.logging.Logger;
 
@@ -413,8 +418,8 @@ public final class ResXmlPatcher {
         docFactory.setFeature(FEATURE_LOAD_DTD, false);
 
         try {
-            docFactory.setAttribute(ACCESS_EXTERNAL_DTD, " ");
-            docFactory.setAttribute(ACCESS_EXTERNAL_SCHEMA, " ");
+            docFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, " ");
+            docFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, " ");
         } catch (IllegalArgumentException ex) {
             LOGGER.warning("JAXP 1.5 Support is required to validate XML");
         }
@@ -454,8 +459,6 @@ public final class ResXmlPatcher {
         }
     }
 
-    private static final String ACCESS_EXTERNAL_DTD = "http://javax.xml.XMLConstants/property/accessExternalDTD";
-    private static final String ACCESS_EXTERNAL_SCHEMA = "http://javax.xml.XMLConstants/property/accessExternalSchema";
     private static final String FEATURE_LOAD_DTD = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
     private static final String FEATURE_DISABLE_DOCTYPE_DECL = "http://apache.org/xml/features/disallow-doctype-decl";
 

--- a/brut.j.dir/src/main/java/brut/directory/FileDirectory.java
+++ b/brut.j.dir/src/main/java/brut/directory/FileDirectory.java
@@ -18,6 +18,7 @@ package brut.directory;
 
 import java.io.*;
 import java.net.URLDecoder;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -36,25 +37,23 @@ public class FileDirectory extends AbstractDirectory {
 
     public FileDirectory(File dir) throws DirectoryException {
         super();
-        if (! dir.isDirectory()) {
+        if (!dir.isDirectory()) {
             throw new DirectoryException("file must be a directory: " + dir);
         }
         mDir = dir;
     }
 
     @Override
-    public long getSize(String fileName)
-            throws DirectoryException {
+    public long getSize(String fileName) throws DirectoryException {
         File file = new File(generatePath(fileName));
-        if (! file.isFile()) {
+        if (!file.isFile()) {
             throw new DirectoryException("file must be a file: " + file);
         }
         return file.length();
     }
 
     @Override
-    public long getCompressedSize(String fileName)
-            throws DirectoryException {
+    public long getCompressedSize(String fileName) throws DirectoryException {
         return getSize(fileName);
     }
 
@@ -69,8 +68,9 @@ public class FileDirectory extends AbstractDirectory {
     @Override
     protected InputStream getFileInputLocal(String name) throws DirectoryException {
         try {
-            return new FileInputStream(generatePath(name));
-        } catch (FileNotFoundException ex) {
+            File file = new File(generatePath(name));
+            return Files.newInputStream(file.toPath());
+        } catch (IOException ex) {
             throw new DirectoryException(ex);
         }
     }
@@ -78,8 +78,9 @@ public class FileDirectory extends AbstractDirectory {
     @Override
     protected OutputStream getFileOutputLocal(String name) throws DirectoryException {
         try {
-            return new FileOutputStream(generatePath(name));
-        } catch (FileNotFoundException ex) {
+            File file = new File(generatePath(name));
+            return Files.newOutputStream(file.toPath());
+        } catch (IOException ex) {
             throw new DirectoryException(ex);
         }
     }
@@ -96,8 +97,9 @@ public class FileDirectory extends AbstractDirectory {
 
     @Override
     protected void removeFileLocal(String name) {
+        File file = new File(generatePath(name));
         //noinspection ResultOfMethodCallIgnored
-        new File(generatePath(name)).delete();
+        file.delete();
     }
 
     private String generatePath(String name) {


### PR DESCRIPTION
Recording feature flags moved to ResourcesDecoder to fix an issue where raw AndroidManifest is attempted to be parsed even when decoding without resources.

Replaced remaining usages of FileInputStream/FileInputStream with their NIO equivalents for consistency with rest of code.

Minor redundancy and format tweaks.