### PR TITLE
feat: add user, system certificate in existing network security config

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkBuilder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkBuilder.java
@@ -343,12 +343,6 @@ public class ApkBuilder {
                 }
 
                 File netSecConfOrig = new File(mApkDir, "res/xml/network_security_config.xml");
-                if (netSecConfOrig.exists()) {
-                    LOGGER.info("Replacing existing network_security_config.xml!");
-                    //noinspection ResultOfMethodCallIgnored
-                    netSecConfOrig.delete();
-                }
-
                 ResXmlPatcher.modNetworkSecurityConfig(netSecConfOrig);
                 ResXmlPatcher.setNetworkSecurityConfig(manifest);
                 LOGGER.info("Added permissive network security config in manifest");


### PR DESCRIPTION
With `-n` flag:
Current flow: creates a new network_security_config and updates in manifest
Updated flow: check if network_security_config exist, if not, create a new one (current approach) else modify network_security_config to add certificate without losing other rules added by user. i.e whitelisting any domain.