### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM gradle:8.11.1-jdk17-alpine AS build
+
+WORKDIR /src
+
+COPY . .
+
+RUN gradle build shadowJar proguard
+
+
+FROM openjdk:11
+
+WORKDIR /data
+
+COPY --from=build /src/brut.apktool/apktool-cli/build/libs/apktool-cli.jar /
+
+ENTRYPOINT ["java", "-Xmx1024M", "-Dfile.encoding=utf-8", "-Djdk.util.zip.disableZip64ExtraFieldValidation=true", "-Djdk.nio.zipfs.allowDotZipEntry=true", "-jar", "/apktool-cli.jar"]


### PR DESCRIPTION
Add multi-stage Dockerfile

Stages:
1. Build .jar with Gradle
2. Copy it to the new container and run it via OpenJDK

To build Apktool Docker image 

```bash
docker build --platform=linux/amd64 -t apktool -f Dockerfile .
```

Usage: decompile and extract APK

```bash
docker run --rm --name apktool-temp --platform=linux/amd64 -v $(pwd):/data/ -it apktool d test.apk
```