### PR TITLE
Fix: regex in numeric Values in meta-data

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AndroidManifestResourceParser.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AndroidManifestResourceParser.java
@@ -37,7 +37,7 @@ public class AndroidManifestResourceParser extends AXmlResourceParser {
      * For details/discussion, see https://stackoverflow.com/questions/2154945/how-to-force-a-meta-data-value-to-type-string
      * With aapt1, the escaped space is dropped when encoded. For aapt2, the escaped space is preserved.
      */
-    private static final Pattern PATTERN_NUMERIC_STRING = Pattern.compile("\\s?\\d+");
+    private static final Pattern PATTERN_NUMERIC_STRING = Pattern.compile("\\\\ \\d+");
 
     @Override
     public String getAttributeValue(int index) {
@@ -54,7 +54,7 @@ public class AndroidManifestResourceParser extends AXmlResourceParser {
         // Otherwise, when the decoded app is rebuilt, aapt will incorrectly encode
         // the value as an int or float (depending on aapt version), breaking the original
         // app functionality.
-        return "\\ " + value.trim();
+        return value.substring(2);
     }
 
     private boolean isNumericStringMetadataAttributeValue(int index, String value) {


### PR DESCRIPTION
I do not know all the details, but the regex seems wrong, as numeric values are prefixed with `\ ` [backslash and space] (as stated in another discussion, https://stackoverflow.com/questions/2154945/how-to-force-a-meta-data-value-to-type-string , and in the file itself).

This won't match with the current regex, meaning all values are non numeric.
For example if I add a log:
```
MetadataValue NOT numeric: '\ 34173474129'
```
which is a numeric value.

In my case this leads to an issue, changing the regex and replace the unnecessary trim with a substring(2). fixes it in my case.

Not sure about any side effect, need to do a bit more testing. Just wanted to drop it here, in case anyone else has issues with numeric metadata values.