### PR TITLE
fix: support featureFlags anywhere

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResXmlUtils.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResXmlUtils.java
@@ -257,7 +257,7 @@ public final class ResXmlUtils {
     public static String[] pullManifestFeatureFlags(File file) {
         try {
             Document doc = XmlUtils.loadDocument(file, true);
-            String expression = "/manifest/permission/@android:featureFlag";
+            String expression = "/manifest//@android:featureFlag";
             NodeList nodes = XmlUtils.evaluateXPath(doc, expression, NodeList.class);
 
             String[] featureFlags = new String[nodes.getLength()];

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/BaseTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/BaseTest.java
@@ -17,7 +17,6 @@
 package brut.androlib;
 
 import brut.androlib.Config;
-import brut.androlib.apk.ApkInfo;
 import brut.androlib.res.Framework;
 import brut.common.BrutException;
 import brut.directory.ExtFile;
@@ -47,7 +46,6 @@ public class BaseTest {
     protected static File sTmpDir;
     protected static ExtFile sTestOrigDir;
     protected static ExtFile sTestNewDir;
-    protected static ApkInfo sTestApkInfo;
 
     private static void cleanFrameworkFile() throws BrutException {
         File apkFile = new File(new Framework(sConfig).getDirectory(), "1.apk");

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/BuildAndDecodeTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt1/BuildAndDecodeTest.java
@@ -172,10 +172,10 @@ public class BuildAndDecodeTest extends BaseTest {
 
     @Test
     public void storedMp3FilesAreNotCompressedTest() throws BrutException, IOException {
-        ExtFile testApk = new ExtFile(sTmpDir, "testapp.apk");
-        Integer compLevel = testApk.getDirectory().getCompressionLevel("res/raw/rain.mp3");
-        testApk.close();
-        assertEquals(Integer.valueOf(0), compLevel);
+        try (ExtFile testApk = new ExtFile(sTmpDir, "testapp.apk")) {
+            Integer compLevel = testApk.getDirectory().getCompressionLevel("res/raw/rain.mp3");
+            assertEquals(Integer.valueOf(0), compLevel);
+        }
     }
 
     @Test
@@ -503,9 +503,7 @@ public class BuildAndDecodeTest extends BaseTest {
     @Test
     public void confirmZeroByteFileExtensionIsNotStored() throws BrutException {
         ApkInfo testInfo = ApkInfo.load(sTestNewDir);
-        for (String path : testInfo.doNotCompress) {
-            assertNotEquals("jpg", path);
-        }
+        assertFalse(testInfo.doNotCompress.contains("jpg"));
     }
 
     @Test

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/BuildAndDecodeTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/BuildAndDecodeTest.java
@@ -49,7 +49,7 @@ public class BuildAndDecodeTest extends BaseTest {
         new ApkBuilder(sTestOrigDir, sConfig).build(testApk);
 
         LOGGER.info("Decoding testapp.apk...");
-        sTestApkInfo = new ApkDecoder(testApk, sConfig).decode(sTestNewDir);
+        new ApkDecoder(testApk, sConfig).decode(sTestNewDir);
     }
 
     @Test
@@ -87,6 +87,13 @@ public class BuildAndDecodeTest extends BaseTest {
     public void valuesBcp47LanguageScriptRegionVariantTest() throws BrutException {
         compareValuesFiles("values-b+ast+Latn+IT+AREVELA/strings.xml");
         compareValuesFiles("values-b+ast+Hant+IT+ARABEXT/strings.xml");
+    }
+
+    @Test
+    public void confirmFeatureFlagsRecorded() throws BrutException {
+        ApkInfo testInfo = ApkInfo.load(sTestNewDir);
+        assertTrue(testInfo.featureFlags.get("brut.feature.permission"));
+        assertTrue(testInfo.featureFlags.get("brut.feature.activity"));
     }
 
     @Test
@@ -157,15 +164,6 @@ public class BuildAndDecodeTest extends BaseTest {
     @Test
     public void unknownFolderTest() throws BrutException {
         compareBinaryFolder("unknown");
-    }
-
-    @Test
-    public void featureFlagTest() {
-        assertNotNull(sTestApkInfo.featureFlags);
-        assertTrue(sTestApkInfo.featureFlags.containsKey("brut.feature.flag"));
-        // assertTrue(sTestApkInfo.featureFlags.containsKey("brut.activity.flag"));
-        assertEquals(true, sTestApkInfo.featureFlags.get("brut.feature.flag"));
-        // assertEquals(true, sTestApkInfo.featureFlags.get("brut.activity.flag"));
     }
 
     @Test

--- a/brut.apktool/apktool-lib/src/test/resources/aapt2/testapp/AndroidManifest.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/aapt2/testapp/AndroidManifest.xml
@@ -10,12 +10,12 @@
         <meta-data name="test_int_as_string" value="\ 12345" />
         <meta-data name="test_int" value="12345" />
     </application>
-    <activity android:name=".MainActivity" android:featureFlag="brut.activity.flag">
+    <activity android:name=".MainActivity" android:featureFlag="brut.feature.activity">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
     </activity>
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
-    <permission android:featureFlag="brut.feature.flag" android:label="Test Permission" android:name="brut.permission.TEST" android:permissionGroup="android.permission-group.UNDEFINED" android:protectionLevel="signature" />
+    <permission android:featureFlag="brut.feature.permission" android:label="Test Permission" android:name="brut.permission.TEST" android:permissionGroup="android.permission-group.UNDEFINED" android:protectionLevel="signature" />
 </manifest>

--- a/brut.apktool/apktool-lib/src/test/resources/aapt2/testapp/apktool.yml
+++ b/brut.apktool/apktool-lib/src/test/resources/aapt2/testapp/apktool.yml
@@ -10,8 +10,8 @@ versionInfo:
   versionCode: '1'
   versionName: '1.0'
 featureFlags:
-  brut.feature.flag: true
-  brut.activity.flag: true
+  brut.feature.permission: true
+  brut.feature.activity: true
 doNotCompress:
 - assets/0byte_file.jpg
 sparseResources: false


### PR DESCRIPTION
Checked aapt2 source and how aapt2 responds to featureFlags specified in tags other than "permission". Apparently it's allowed to appear on any tag inside "manifest" as it's being pre-processed. An easy fix.

Fixes https://github.com/iBotPeaches/Apktool/issues/3768