### PR TITLE
feat: add Dockerfile and launching script for it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM gradle:8.11.1-jdk17-alpine AS build
+
+WORKDIR /src
+
+COPY . .
+
+RUN gradle build shadowJar proguard
+
+
+FROM openjdk:11
+
+WORKDIR /data
+
+COPY --from=build /src/brut.apktool/apktool-cli/build/libs/apktool-cli.jar /
+
+ENTRYPOINT ["java", "-Xmx1024M", "-Dfile.encoding=utf-8", "-Djdk.util.zip.disableZip64ExtraFieldValidation=true", "-Djdk.nio.zipfs.allowDotZipEntry=true", "-jar", "/apktool-cli.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,12 @@ COPY . .
 RUN gradle build shadowJar proguard
 
 
-FROM openjdk:11
+FROM gcr.io/distroless/java:11
 
 WORKDIR /data
 
 COPY --from=build /src/brut.apktool/apktool-cli/build/libs/apktool-cli.jar /
+
+USER nonroot
 
 ENTRYPOINT ["java", "-Xmx1024M", "-Dfile.encoding=utf-8", "-Djdk.util.zip.disableZip64ExtraFieldValidation=true", "-Djdk.nio.zipfs.allowDotZipEntry=true", "-jar", "/apktool-cli.jar"]

--- a/docker/apktool.sh
+++ b/docker/apktool.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash -i -e
+
+# This one-liner simply passes the command line arguments and binds the workdir as a mount point to it
+
+docker run --rm --name apktool --platform=linux/amd64 --volume $(pwd -P):/data:rw -it apktool:latest "$@"


### PR DESCRIPTION
Add multi-stage Dockerfile and launching script for it

Stages:
* Build .jar with Gradle
* Copy it to the new container and run it via OpenJDK

I considered simplicity of use. Now, there’s no need to write complex docker commands. You just need to use the following script (`./docker/apktool.sh`) and pass the required arguments for Apktool

Usage:

Clone the repo and move to it. Then build the image and use the shell wrapper to run apktool via docker:

```bash
git clone https://github.com/iBotPeaches/Apktool
cd Apktool
docker build --platform=linux/amd64 -t apktool:latest -f Dockerfile .
./docker/apktool.sh d example.apk -o decompressed_example_apk
./docker/apktool.sh b decompressed_example_apk -o assembled_example_apk.apk
```
