### PR TITLE
Fix disassembly of WhatsApp w/ un-ordered resources.

### DIFF
--- a/brut.j.util/src/main/java/brut/util/ExtDataInputStream.java
+++ b/brut.j.util/src/main/java/brut/util/ExtDataInputStream.java
@@ -50,7 +50,7 @@ public class ExtDataInputStream extends FilterInputStream implements ExtDataInpu
         mCountIn = countIn;
     }
 
-    public void jump(long expectedPosition) throws IOException {
+    public void jumpTo(long expectedPosition) throws IOException {
         long position = this.position();
         if (position > expectedPosition) {
             throw new IOException(String.format("Jumping backwards from %d to %d", position, expectedPosition));

--- a/brut.j.util/src/main/java/brut/util/ExtDataInputStream.java
+++ b/brut.j.util/src/main/java/brut/util/ExtDataInputStream.java
@@ -50,6 +50,19 @@ public class ExtDataInputStream extends FilterInputStream implements ExtDataInpu
         mCountIn = countIn;
     }
 
+    public void jump(long expectedPosition) throws IOException {
+        long position = this.position();
+        if (position > expectedPosition) {
+            throw new IOException(String.format("Jumping backwards from %d to %d", position, expectedPosition));
+        }
+        if (position < expectedPosition) {
+            long skipped = skip(expectedPosition - position);
+            if (skipped != expectedPosition - position) {
+                throw new IOException(String.format("Jump failed: expected %d, got %d", expectedPosition - position, skipped));
+            }
+        }
+    }
+
     // ExtDataInput
 
     @Override

--- a/brut.j.xml/src/main/java/brut/xmlpull/MXSerializer.java
+++ b/brut.j.xml/src/main/java/brut/xmlpull/MXSerializer.java
@@ -204,6 +204,9 @@ public class MXSerializer implements XmlSerializer {
     }
 
     private void write(String str) throws IOException {
+        if (str == null) {
+            str = "";
+        }
         write(str, 0, str.length());
     }
 


### PR DESCRIPTION
Fixes #3778.

It was noticed that resources were crashing out during disassembly. It seemed a premature exit, but instead the offsets were behind the current location in the stream. Apktool historically had always read entries in order and for the better part of a decade - that worked.

Recently (years ago) obfuscation techniques led Apktool to leveraging a buffered stream alongside a counting stream to properly detect positions in a chunk for skipping, etc. This allowed Apktool to check its current position in order to skip bytes to re-align itself for parsing.

These applications required rewinding the location to the beginning of the chunk so the offset could be properly skipped towards it. So this made a few changes:

 * We start a buffered stream as we enter the TYPE chunk (mark)
 * If our expected entry start is behind our current position we reset and jump back (reset)
 * We continue on.

This seemed valid in theory, but failed in actuality because Apktool offsets for sparse/16bit had [been broken](https://github.com/iBotPeaches/Apktool/pull/3372) since introduction in early 2023. This meant as this patch had put a dependency on valid offsets so it could properly skip meant it exposed a flaw that offsets were encoded improperly.

Changes:

 * Remove manual alignment to beginning of entry chunk (because we have a jumpTo now)
 * Rename `readEntry` to `parseEntryData` because `read` suggests reading data from stream, which it does not
 * Automatically reset stream to mark point (beginning of chunk) if offset is behind current location
 * Correct 16bit offset storage to store real offset (offset * 4u)
 * Correct an NPE for serializing null