### PR TITLE
fix: check for oob after jumps in table spec

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
@@ -350,6 +350,13 @@ public class ARSCDecoder {
                 continue;
             }
 
+            // #3778 - In some applications the res entries are unordered and might have to jump backwards.
+            long entryStart = entriesStartAligned + offset;
+            if (entryStart < mIn.position()) {
+                mIn.reset();
+            }
+            mIn.jumpTo(entryStart);
+
             // As seen in some recent APKs - there are more entries reported than can fit in the chunk.
             if (mIn.position() >= mHeader.endPosition) {
                 int remainingEntries = entryCount - i;
@@ -358,13 +365,6 @@ public class ARSCDecoder {
                 ));
                 break;
             }
-
-            // #3778 - In some applications the res entries are unordered and might have to jump backwards.
-            long entryStart = entriesStartAligned + offset;
-            if (entryStart < mIn.position()) {
-                mIn.reset();
-            }
-            mIn.jumpTo(entryStart);
 
             EntryData entryData = readEntryData();
             if (entryData != null) {


### PR DESCRIPTION
After https://github.com/iBotPeaches/Apktool/pull/3799 it was determined we exited too early - we should exit after the jumps, in case the elements are out of order and we jump prior to the entire set being read.

fixes: #3778 (again)
