### PR TITLE
fix: update XML element retrieval to use correct parent nodes

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResXmlUtils.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResXmlUtils.java
@@ -143,21 +143,21 @@ public final class ResXmlUtils {
                 changed = true;
             }
 
-            Element baseConfig = (Element) doc.getElementsByTagName("base-config").item(0);
+            Element baseConfig = (Element) root.getElementsByTagName("base-config").item(0);
             if (baseConfig == null) {
                 baseConfig = doc.createElement("base-config");
                 root.appendChild(baseConfig);
                 changed = true;
             }
 
-            Element trustAnchors = (Element) doc.getElementsByTagName("trust-anchors").item(0);
+            Element trustAnchors = (Element) baseConfig.getElementsByTagName("trust-anchors").item(0);
             if (trustAnchors == null) {
                 trustAnchors = doc.createElement("trust-anchors");
                 baseConfig.appendChild(trustAnchors);
                 changed = true;
             }
 
-            NodeList certificates = doc.getElementsByTagName("certificates");
+            NodeList certificates = trustAnchors.getElementsByTagName("certificates");
             boolean hasSystemCert = false;
             boolean hasUserCert = false;
             for (int i = 0; i < certificates.getLength(); i++) {

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/NetworkConfigTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/aapt2/NetworkConfigTest.java
@@ -65,12 +65,12 @@ public class NetworkConfigTest extends BaseTest {
         Document doc = loadDocument(new File(sTestNewDir, "res/xml/network_security_config.xml"));
 
         // Check if 'system' certificate exists
-        String systemCertExpr = "//certificates[@src='system']";
+        String systemCertExpr = "//base-config//certificates[@src='system']";
         NodeList systemCertNodes = evaluateXPath(doc, systemCertExpr, NodeList.class);
         assertTrue(systemCertNodes.getLength() > 0);
 
         // Check if 'user' certificate exists
-        String userCertExpr = "//certificates[@src='user']";
+        String userCertExpr = "//base-config//certificates[@src='user']";
         NodeList userCertNodes = evaluateXPath(doc, userCertExpr, NodeList.class);
         assertTrue(userCertNodes.getLength() > 0);
     }

--- a/brut.apktool/apktool-lib/src/test/resources/aapt2/network_config/res/xml/network_security_config.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/aapt2/network_config/res/xml/network_security_config.xml
@@ -5,5 +5,8 @@
         <pin-set>
             <pin digest="SHA-256">OEJax6JVAMiUP7wzOiLPU7KW38Cdx3afNZOYR2iOFZ4=</pin>
         </pin-set>
+        <trust-anchors>
+            <certificates src="user" />
+        </trust-anchors>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
Handling the case when the network security configs already exist under the `<debug-overrides/>` element.
We should look for the next element under the new element we created/found.

Currently:
```
<network-security-config>
    <debug-overrides>
        <trust-anchors>
            <certificates src="user" />
            <certificates src="system" /> --- Added line
        </trust-anchors>
    </debug-overrides>
    <base-config /> --- Added line
</network-security-config>
```

Expected:
```
<network-security-config>
    <debug-overrides>
        <trust-anchors>
            <certificates src="user" />
        </trust-anchors>
    </debug-overrides>
    <base-config>
        <trust-anchors>
            <certificates src="system" />
            <certificates src="user" />
        </trust-anchors>
    </base-config>
</network-security-config>
```
Example package: `com.tradingview.tradingviewapp`
