### PR TITLE
fix: roundtrip XML values containing CDATA-like strings

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResXmlEncoders.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResXmlEncoders.java
@@ -30,7 +30,11 @@ public final class ResXmlEncoders {
     }
 
     public static String escapeXmlChars(String str) {
-        return StringUtils.replace(StringUtils.replace(str, "&", "&amp;"), "<", "&lt;");
+        return StringUtils.replaceEach(
+            str,
+            new String[]{ "&", "<", "]]>" },
+            new String[]{ "&amp;", "&lt;", "]]&gt;" }
+        );
     }
 
     public static String encodeAsResXmlAttr(String str) {

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/res/xml/ResXmlEncodersTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/res/xml/ResXmlEncodersTest.java
@@ -1,0 +1,36 @@
+package brut.androlib.res.xml;
+
+import brut.androlib.BaseTest;
+import brut.xml.XmlUtils;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+import static org.junit.Assert.assertEquals;
+
+public class ResXmlEncodersTest extends BaseTest {
+    @Test
+    public void escapeXmlCharsEscapeExpected() {
+        assertEquals("foo", ResXmlEncoders.escapeXmlChars("foo"));
+        assertEquals("foo&amp;bar", ResXmlEncoders.escapeXmlChars("foo&bar"));
+        assertEquals("&lt;foo>", ResXmlEncoders.escapeXmlChars("<foo>"));
+        assertEquals("&lt;![CDATA[foo]]&gt;", ResXmlEncoders.escapeXmlChars("<![CDATA[foo]]>"));
+    }
+
+    private static void assertRoundtrips(String value) throws Throwable {
+        String escaped = ResXmlEncoders.escapeXmlChars(value);
+        Document doc = XmlUtils.loadDocumentContent("<root>" + escaped + "</root>", false);
+        Node node = doc.getElementsByTagName("root").item(0);
+        assertEquals(value, node.getTextContent());
+    }
+
+    @Test
+    public void escapeXmlCharsRoundtrip() throws Throwable {
+        assertRoundtrips("foo");
+        assertRoundtrips("'foo'");
+        assertRoundtrips("\"foo\"");
+        assertRoundtrips("foo&bar");
+        assertRoundtrips("<foo>");
+        assertRoundtrips("<![CDATA[foo]]>");
+    }
+}

--- a/brut.j.xml/src/main/java/brut/xml/XmlUtils.java
+++ b/brut.j.xml/src/main/java/brut/xml/XmlUtils.java
@@ -82,6 +82,14 @@ public final class XmlUtils {
         return loadDocument(file, false);
     }
 
+    public static Document loadDocumentContent(String content, boolean nsAware)
+        throws IOException, SAXException, ParserConfigurationException {
+        DocumentBuilder builder = newDocumentBuilder(nsAware);
+        try (InputStream in = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))) {
+            return builder.parse(in);
+        }
+    }
+
     public static Document loadDocument(File file, boolean nsAware)
             throws IOException, SAXException, ParserConfigurationException {
         DocumentBuilder builder = newDocumentBuilder(nsAware);


### PR DESCRIPTION
This fixes the case where the value (text content) for an XML element that needs to be escaped contains text looking like the ending of a CDATA tag (`]]>`) as this must be escaped.

Relevant specification: https://www.w3.org/TR/xml/#syntax

> In the content of elements, character data is any string of characters which does not contain the start-delimiter of any markup and does not include the CDATA-section-close delimiter, " ]]> ".