### PR TITLE
Escape '&' characters inside of data values in AndroidManifest.xml

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AXmlResourceParser.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AXmlResourceParser.java
@@ -448,7 +448,7 @@ public class AXmlResourceParser implements XmlResourceParser {
                     || valueType == TypedValue.TYPE_DYNAMIC_REFERENCE
                     || valueType == TypedValue.TYPE_ATTRIBUTE
                     || valueType == TypedValue.TYPE_DYNAMIC_ATTRIBUTE) {
-                resourceMapValue = decodeFromResourceId(valueData);
+                resourceMapValue = ResXmlEncoders.escapeXmlChars(decodeFromResourceId(valueData));
             }
             String value = getPreferredString(stringBlockValue, resourceMapValue);
 


### PR DESCRIPTION
This will escape '&' characters inside of data values in the reconstitution of AndroidManifest.xml

I had an issue rebuilding an Apk because of an ampersand inside of a data value.

The error :
```bash
I: Checking whether sources has changed...
[Fatal Error] :314:135: The reference to entity "number_of_minutes" must end with the ';' delimiter.
I: Checking whether resources has changed...
I: Building resources...
W: %LOCALAPPDATA%\Temp\apk-mitm-63b54e009617e555baadc87b8c93e678\decode\AndroidManifest.xml:314: error: not well-formed (invalid token).
```

The problematic AndroidManifest.xml
```xml
<intent-filter>
    <action android:name="android.intent.action.VIEW"/>
    <category android:name="android.intent.category.DEFAULT"/>
    <category android:name="android.intent.category.BROWSABLE"/>
    <data android:path="/set-up-sleep-timer-duration-hours-and-minutes?number_of_hours={number_of_hours}&number_of_minutes={number_of_minutes}"/>
</intent-filter>
```

After escaping the character manually there were no issue rebuilding the Apk.