### PR TITLE
Handle another round of "ApkEditor" Protect decoding.

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/arsc/ARSCHeader.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/arsc/ARSCHeader.java
@@ -99,8 +99,4 @@ public class ARSCHeader {
             }
         }
     }
-
-    public void skipChunk(ExtDataInput in) throws IOException {
-        in.skipBytes(chunkSize - headerSize);
-    }
 }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/ARSCDecoder.java
@@ -167,7 +167,7 @@ public class ARSCDecoder {
         mHeader.checkForUnreadHeader(mIn);
 
         LOGGER.warning("Skipping unknown chunk data of size " + mHeader.chunkSize);
-        mHeader.skipChunk(mIn);
+        mIn.jumpTo(mHeader.endPosition);
     }
 
     private ResPackage readTablePackage() throws AndrolibException, IOException {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AXmlResourceParser.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AXmlResourceParser.java
@@ -799,6 +799,8 @@ public class AXmlResourceParser implements XmlResourceParser {
                     int uri = mIn.readInt();
                     mNamespaces.push(prefix, uri);
                 } else {
+                    // #3838 - Some applications have a bogus element prior to the START_ELEMENT event. This breaks parsing &
+                    // until we have a robust chunk parser to handle this, this skip will suffice for now.
                     if (!mHasEncounteredStartElement) {
                         LOGGER.warning(String.format("Skipping end namespace event at %d, element has not been encountered.", arscHeader.endPosition));
                         mIn.jumpTo(arscHeader.endPosition);

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AXmlResourceParser.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/AXmlResourceParser.java
@@ -66,6 +66,7 @@ public class AXmlResourceParser implements XmlResourceParser {
     private final NamespaceStack mNamespaces;
 
     private boolean mIsOperational;
+    private boolean mHasEncounteredStartElement;
     private ExtDataInputStream mIn;
     private StringBlock mStringBlock;
     private int[] mResourceIds;
@@ -109,6 +110,7 @@ public class AXmlResourceParser implements XmlResourceParser {
             return;
         }
         mIsOperational = false;
+        mHasEncounteredStartElement = false;
         mIn = null;
         mStringBlock = null;
         mResourceIds = null;
@@ -754,6 +756,7 @@ public class AXmlResourceParser implements XmlResourceParser {
 
             int chunkType;
             int headerSize = 0;
+            long position = mIn.position();
             if (event == START_DOCUMENT) {
                 // Fake event, see CHUNK_XML_START_TAG handler.
                 chunkType = ARSCHeader.RES_XML_START_ELEMENT_TYPE;
@@ -771,10 +774,11 @@ public class AXmlResourceParser implements XmlResourceParser {
                 continue;
             }
 
+            ARSCHeader arscHeader;
             if (chunkType < ARSCHeader.RES_XML_FIRST_CHUNK_TYPE || chunkType > ARSCHeader.RES_XML_LAST_CHUNK_TYPE) {
-                int chunkSize = mIn.readInt();
-                mIn.skipBytes(chunkSize - 8);
-                LOGGER.warning(String.format("Unknown chunk type at: (0x%08x) skipping...", mIn.position()));
+                arscHeader = new ARSCHeader((short) chunkType, headerSize, mIn.readInt(), position);
+                mIn.jumpTo(arscHeader.endPosition);
+                LOGGER.warning(String.format("Chunk type %s is not supported, skipping...", arscHeader.type));
                 break;
             }
 
@@ -785,7 +789,7 @@ public class AXmlResourceParser implements XmlResourceParser {
             }
 
             // Read remainder of ResXMLTree_node
-            mIn.skipInt(); // chunkSize
+            arscHeader = new ARSCHeader((short) chunkType, headerSize, mIn.readInt(), position);
             mLineNumber = mIn.readInt();
             mIn.skipInt(); // Optional XML Comment
 
@@ -795,6 +799,12 @@ public class AXmlResourceParser implements XmlResourceParser {
                     int uri = mIn.readInt();
                     mNamespaces.push(prefix, uri);
                 } else {
+                    if (!mHasEncounteredStartElement) {
+                        LOGGER.warning(String.format("Skipping end namespace event at %d, element has not been encountered.", arscHeader.endPosition));
+                        mIn.jumpTo(arscHeader.endPosition);
+                        break;
+                    }
+
                     mIn.skipInt(); // prefix
                     mIn.skipInt(); // uri
                     mNamespaces.pop();
@@ -804,13 +814,14 @@ public class AXmlResourceParser implements XmlResourceParser {
                 // are packed with a larger header of unknown data.
                 if (headerSize > 0x10) {
                     int bytesToSkip = headerSize - 0x10;
-                    LOGGER.warning(String.format("AXML header larger than 0x10 bytes, skipping %d bytes.", bytesToSkip));
+                    LOGGER.warning(String.format("AXML START/END namespace header larger than 0x10 bytes, skipping %d bytes.", bytesToSkip));
                     mIn.skipBytes(bytesToSkip);
                 }
                 continue;
             }
 
             if (chunkType == ARSCHeader.RES_XML_START_ELEMENT_TYPE) {
+                mHasEncounteredStartElement = true;
                 mNamespaceIndex = mIn.readInt();
                 mNameIndex = mIn.readInt();
                 mIn.skipShort(); // attributeStart

--- a/brut.j.xml/src/main/java/brut/xmlpull/XmlPullUtils.java
+++ b/brut.j.xml/src/main/java/brut/xmlpull/XmlPullUtils.java
@@ -51,6 +51,9 @@ public final class XmlPullUtils {
 
         while (true) {
             int event = in.nextToken();
+            if (event == -1) {
+                break;
+            }
             if (event == XmlPullParser.START_DOCUMENT) {
                 out.startDocument(in.getInputEncoding(), standalone);
                 continue;


### PR DESCRIPTION
ApkEditor made some improvements which broke Apktool, but kept working on AOSP. Things I saw:

* ApkEditor will make a StringPool chunk and then mislabel the type as something else. So if you are reading the chunk and parse via the type - it'll crash out. This is sneaky because AOSP does not parse any chunks except the one it cares about. So in the situation where AOSP parses `AndroidManifest.xml` it parses ahead (reading header, jumping to end of chunk) until it finds a few elements and in this case `START_ELEMENT`. So when ApkEditor packs bogus chunks of `XML_END_NAMESPACE` and `PACKAGE` Apktool may crash out as it tries to parse those as-is in the middle of an XML node and die.

```java
    private void placeBadChunk(AndroidManifestBlock manifestBlock) {
        placeBadChunk(manifestBlock, ChunkType.XML_END_NAMESPACE);
        placeBadChunk(manifestBlock, ChunkType.PACKAGE);
    }
```
https://github.com/REAndroid/APKEditor/commit/4e7ce005e29a72cb97fd8719c1056b2218802a0e

So Apktool made a few changes:

1. Aligned towards the `jumpTo` method instead of having `skip` lines around. Even though it does the same thing under the hood - its a bit easier to read/understand. This is helpful because ApkEditor injects a StringPool then marks it as a Package type. So our older code would have attempted to parse the Package type (even if it was going to skip it). So now it just skips a chunk that it does not care about without parsing more than the arsc header.
2. Removed the hard-coded assumption of header size, which may be different when bogus chunks are injected into the XML area of the manifest.
3. Detects if a END_NAMESPACE event is obtained prior to START_ELEMENT. If so - it just skips that chunk.

---

This isn't perfect yet as END_NAMESPACE bogus element could just become any other and Apktool would break again. However, the 15 year old XML node reading code isn't as elegant at the moment to transition into a while() loop of parsing chunks with a preference to skip unknown chunks. 

fixes: #3838 
