### PR TITLE
fix: rename resources when package name is changed

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/AaptInvoker.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/AaptInvoker.java
@@ -145,6 +145,9 @@ public class AaptInvoker {
 
             cmd.add("--rename-instrumentation-target-package");
             cmd.add(mApkInfo.getPackageInfo().getRenameManifestPackage());
+
+            cmd.add("--rename-resources-package");
+            cmd.add(mApkInfo.getPackageInfo().getRenameManifestPackage());
         }
         if (mApkInfo.getVersionInfo().getVersionCode() != null) {
             cmd.add("--version-code");


### PR DESCRIPTION
# Why

trying to fix the issue when `renameManifestPackage` is specified, package name in resources.arsc isn't updated. i tested with `--use-aapt2`, which is also the implicit default in the latest version.

# How

aapt2 has an additional `--rename-resources-package` option and we should use it in `renameManifestPackage` case.

# Test Plan

manual tests

```sh
# use a random sample apk to test
$ apktool d brut.apktool/apktool-lib/src/test/resources/issue2836/issue2836.apk -o testapp

# add renameManifestPackage
$ yq -i '.packageInfo.renameManifestPackage = "com.example.aapt2"' testapp/apktool.yml

# tested with official apktool v2.11.1
$ apktool b -o testapp.apk testapp
$ aapt2 dump resources testapp.apk | grep 'Package name='
Package name=com.ibotpeaches.issue2836 id=7f

# tested with my local build with the patch
$ java -jar ./brut.apktool/apktool-cli/build/libs/apktool-v*.jar b -o testapp.apk testapp
$ aapt2 dump resources testapp.apk | grep 'Package name='
Package name=com.example.aapt2 id=7f
```