### PR TITLE
smali: restore -api option and limit to 29

### DIFF
--- a/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
+++ b/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
@@ -190,6 +190,13 @@ public class Main {
             .desc("Use aapt1 binary instead of aapt2 during the build step.")
             .build();
 
+    private static final Option buildApiLevelOption = Option.builder("api")
+            .longOpt("api-level")
+            .desc("Force the API level to use for smali to <api>.")
+            .hasArg()
+            .argName("api")
+            .build();
+
     private static final Option buildOutputOption = Option.builder("o")
             .longOpt("output")
             .desc("Output the built apk to <file>. (default: dist/name.apk)")
@@ -261,6 +268,7 @@ public class Main {
             buildOptions.addOption(libOption);
             if (advanced) {
                 buildOptions.addOption(buildAaptOption);
+                buildOptions.addOption(buildApiLevelOption);
                 buildOptions.addOption(buildCopyOriginalOption);
                 buildOptions.addOption(buildDebugOption);
                 buildOptions.addOption(buildNetSecConfOption);
@@ -587,6 +595,9 @@ public class Main {
             } else {
                 config.setAaptVersion(1);
             }
+        }
+        if (cli.hasOption(buildApiLevelOption)) {
+            config.setBaksmaliApiLevel(Integer.parseInt(cli.getOptionValue(buildApiLevelOption)));
         }
 
         File outFile = null;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkBuilder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkBuilder.java
@@ -205,7 +205,10 @@ public class ApkBuilder {
         OS.rmfile(dex);
 
         LOGGER.info("Smaling " + dirName + " folder into " + fileName + "...");
-        SmaliBuilder builder = new SmaliBuilder(smaliDir, mMinSdkVersion);
+        // limit opcode api level to 29 or below (dex version up to 039)
+        int apiLevel = Math.min(29, mConfig.getBaksmaliApiLevel() > 0
+            ? mConfig.getBaksmaliApiLevel() : mMinSdkVersion);
+        SmaliBuilder builder = new SmaliBuilder(smaliDir, apiLevel);
         builder.build(dex);
     }
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResFileValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResFileValue.java
@@ -16,24 +16,12 @@
  */
 package brut.androlib.res.data.value;
 
-import brut.androlib.exceptions.AndrolibException;
-
 public class ResFileValue extends ResIntBasedValue {
     private final String mPath;
 
     public ResFileValue(String path, int rawIntValue) {
         super(rawIntValue);
         mPath = path;
-    }
-
-    public String getStrippedPath() throws AndrolibException {
-        if (mPath.startsWith("res/")) {
-            return mPath.substring(4);
-        }
-        if (mPath.startsWith("r/") || mPath.startsWith("R/")) {
-            return mPath.substring(2);
-        }
-        throw new AndrolibException("File path does not start with \"res/\" or \"r/\": " + mPath);
     }
 
     @Override


### PR DESCRIPTION
Restored the `-api` option for `build` mode for now, and limited opcode API level for `SmaliBuilder` to <= 29.

Realistically, the `-api` option is obsolete for both `decode` and `build` modes, because the process is already automatic and shouldn't be messed with.

All we had to do is limit the opcode API level for `SmaliBuilder` to make sure we assemble dex 039 or older.
dex 040 and 041 don't exist in the wild, and smali assembling for dex 041 is broken for a long time now (writes incomplete header).