### PR TITLE
chore: shorten version logic

### DIFF
--- a/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
+++ b/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
@@ -306,14 +306,6 @@ public class Main {
             return;
         }
 
-        // Keep support for older (-version/--version) command line arguments
-        for (String arg : args) {
-            if (arg.equals("-version") || arg.equals("--version")) {
-                printVersion();
-                return;
-            }
-        }
-
         String cmdName = args[0];
         String[] cmdArgs = Arrays.copyOfRange(args, 1, args.length);
 
@@ -349,6 +341,8 @@ public class Main {
                 break;
             case "v":
             case "version":
+            case "-version":
+            case "--version":
                 printVersion();
                 break;
             default:


### PR DESCRIPTION
```
➜  Apktool git:(main) ✗ apktool v
v2.12.1-15-6a0bae60-SNAPSHOT
➜  Apktool git:(main) ✗ apktool version
v2.12.1-15-6a0bae60-SNAPSHOT
➜  Apktool git:(main) ✗ apktool -version
v2.12.1-15-6a0bae60-SNAPSHOT
➜  Apktool git:(main) ✗ apktool --version
v2.12.1-15-6a0bae60-SNAPSHOT
```