### PR TITLE
Use binary name "aapt2" as prefix for temporary file

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AaptManager.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AaptManager.java
@@ -45,11 +45,11 @@ public final class AaptManager {
 
         StringBuilder binPath = new StringBuilder("/prebuilt/");
         if (OSDetection.isUnix()) {
-            binPath.append("linux");
+            binPath.append("linux"); // ELF 64-bit LSB executable, x86-64
         } else if (OSDetection.isMacOSX()) {
-            binPath.append("macosx");
+            binPath.append("macosx"); // fat binary x86_64 + arm64
         } else if (OSDetection.isWindows()) {
-            binPath.append("windows");
+            binPath.append("windows"); // x86_64
         } else {
             throw new AndrolibException("Could not identify platform: " + OSDetection.returnOS());
         }
@@ -61,7 +61,7 @@ public final class AaptManager {
 
         File binFile;
         try {
-            binFile = Jar.getResourceAsFile(AaptManager.class, binPath.toString());
+            binFile = Jar.getResourceAsFile(AaptManager.class, binPath.toString(), binName + "_");
         } catch (BrutException ex) {
             throw new AndrolibException(ex);
         }

--- a/brut.j.util/src/main/java/brut/util/Jar.java
+++ b/brut.j.util/src/main/java/brut/util/Jar.java
@@ -36,9 +36,13 @@ public final class Jar {
     }
 
     public static File getResourceAsFile(Class<?> clz, String name) throws BrutException {
+        return getResourceAsFile(clz, name, "brut_util_Jar_");
+    }
+
+    public static File getResourceAsFile(Class<?> clz, String name, String tmpPrefix) throws BrutException {
         File file = sExtracted.get(name);
         if (file == null) {
-            file = extractToTmp(clz, name);
+            file = extractToTmp(clz, name, tmpPrefix);
             sExtracted.put(name, file);
         }
         return file;

--- a/brut.j.util/src/main/java/brut/util/OS.java
+++ b/brut.j.util/src/main/java/brut/util/OS.java
@@ -145,7 +145,7 @@ public final class OS {
 
             int exitValue = ps.waitFor();
             if (exitValue != 0) {
-                throw new BrutException("could not exec (exit code = " + exitValue + "): " + Arrays.toString(cmd));
+                throw new BrutException("Execution failed (exit code = " + exitValue + "): " + Arrays.toString(cmd));
             }
         } catch (IOException ex) {
             throw new BrutException("could not exec: " + Arrays.toString(cmd), ex);


### PR DESCRIPTION
When executing the prebuilt aapt2 binary apktool uses by default a generic tmp file prefix which makes it difficult to understand for end-users what went wrong when aapt2 building failed. 
Therefore I changed the prefix to reflect the actual binary name "aapt2". 

In addition the error message "could not exec..." was changed if aapt2 has an exit code != 0, as in my opinion it was misleading as aapt2 could be executed fine, just if failed to build the resources.