### PR TITLE
refactor: modernize --res-resolve-mode and dummies

### DIFF
--- a/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
+++ b/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
@@ -49,12 +49,12 @@ public class Main {
     private static final Option verboseOption = Option.builder("v")
         .longOpt("verbose")
         .desc("Increase output verbosity.")
-        .build();
+        .get();
 
     private static final Option quietOption = Option.builder("q")
         .longOpt("quiet")
         .desc("Suppress normal output.")
-        .build();
+        .get();
 
     private static final Option jobsOption = Option.builder("j")
         .longOpt("jobs")
@@ -62,21 +62,21 @@ public class Main {
         .hasArg()
         .argName("num")
         .type(Integer.class)
-        .build();
+        .get();
 
     private static final Option frameDirOption = Option.builder("p")
         .longOpt("frame-path")
         .desc("Use framework files located in <dir>.")
         .hasArg()
         .argName("dir")
-        .build();
+        .get();
 
     private static final Option frameTagOption = Option.builder("t")
         .longOpt("frame-tag")
         .desc("Use framework files tagged with <tag>.")
         .hasArg()
         .argName("tag")
-        .build();
+        .get();
 
     private static final Option libOption = Option.builder("l")
         .longOpt("lib")
@@ -84,45 +84,45 @@ public class Main {
             + "Can be specified multiple times.")
         .hasArg()
         .argName("package:file")
-        .build();
+        .get();
 
     private static final Option decodeForceOption = Option.builder("f")
         .longOpt("force")
         .desc("Force delete destination directory.")
-        .build();
+        .get();
 
     private static final Option decodeNoSrcOption = Option.builder("s")
         .longOpt("no-src")
         .desc("Do not decode sources.")
-        .build();
+        .get();
 
     private static final Option decodeOnlyMainClassesOption = Option.builder()
         .longOpt("only-main-classes")
         .desc("Only disassemble the main dex classes (classes[0-9]*.dex) in the root.")
-        .build();
+        .get();
 
     private static final Option decodeNoDebugInfoOption = Option.builder()
         .longOpt("no-debug-info")
         .desc("Do not include debug info in sources (.local, .param, .line, etc.)")
-        .build();
+        .get();
 
     private static final Option decodeNoResOption = Option.builder("r")
         .longOpt("no-res")
         .desc("Do not decode resources.")
-        .build();
+        .get();
 
     private static final Option decodeOnlyManifestOption = Option.builder()
         .longOpt("only-manifest")
         .desc("Only decode AndroidManifest.xml without resources.")
-        .build();
+        .get();
 
     private static final Option decodeResResolveModeOption = Option.builder()
         .longOpt("res-resolve-mode")
         .desc("Set the resolve mode for resources to <mode>.\n"
-            + "Possible values are: 'keep' (default), 'remove' or 'dummy'.")
+            + "Possible values: 'default', 'greedy' or 'lazy'.")
         .hasArg()
         .argName("mode")
-        .build();
+        .get();
 
     private static final Option decodeKeepBrokenResOption = Option.builder()
         .longOpt("keep-broken-res")
@@ -130,87 +130,87 @@ public class Main {
             + "\"Invalid config flags detected. Dropping resources\", but you\n"
             + "want to decode them anyway, even with errors. You will have to\n"
             + "fix them manually before building.")
-        .build();
+        .get();
 
     private static final Option decodeMatchOriginalOption = Option.builder()
         .longOpt("match-original")
         .desc("Keep files closest to original as possible (prevents rebuild).")
-        .build();
+        .get();
 
     private static final Option decodeNoAssetsOption = Option.builder()
         .longOpt("no-assets")
         .desc("Do not decode assets.")
-        .build();
+        .get();
 
     private static final Option decodeOutputOption = Option.builder("o")
         .longOpt("output")
         .desc("Output decoded files to <dir>. (default: apk.out)")
         .hasArg()
         .argName("dir")
-        .build();
+        .get();
 
     private static final Option buildForceOption = Option.builder("f")
         .longOpt("force")
         .desc("Skip changes detection and build all files.")
-        .build();
+        .get();
 
     private static final Option buildNoApkOption = Option.builder()
         .longOpt("no-apk")
         .desc("Disable repacking of the built files into a new apk.")
-        .build();
+        .get();
 
     private static final Option buildNoCrunchOption = Option.builder()
         .longOpt("no-crunch")
         .desc("Disable crunching of resource files during the build step.")
-        .build();
+        .get();
 
     private static final Option buildCopyOriginalOption = Option.builder()
         .longOpt("copy-original")
         .desc("Copy original AndroidManifest.xml and META-INF. See project page for more info.")
-        .build();
+        .get();
 
     private static final Option buildDebuggableOption = Option.builder()
         .longOpt("debuggable")
         .desc("Set android:debuggable to \"true\" in AndroidManifest.xml for the built apk.")
-        .build();
+        .get();
 
     private static final Option buildNetSecConfOption = Option.builder()
         .longOpt("net-sec-conf")
         .desc("Add a generic network security configuration file to the built apk.")
-        .build();
+        .get();
 
     private static final Option buildAaptOption = Option.builder()
         .longOpt("aapt")
         .desc("Use aapt2 binary located in <file>.")
         .hasArg()
         .argName("file")
-        .build();
+        .get();
 
     private static final Option buildOutputOption = Option.builder("o")
         .longOpt("output")
         .desc("Output the built apk to <file>. (default: dist/name.apk)")
         .hasArg()
         .argName("file")
-        .build();
+        .get();
 
     private static final Option frameFrameDirOption = Option.builder("p")
         .longOpt("frame-path")
         .desc("Set the path for framework files to <dir>.")
         .hasArg()
         .argName("dir")
-        .build();
+        .get();
 
     private static final Option frameFrameTagOption = Option.builder("t")
         .longOpt("frame-tag")
         .desc("Suffix framework files with <tag>.")
         .hasArg()
         .argName("tag")
-        .build();
+        .get();
 
     private static final Option frameForceAllOption = Option.builder("a")
         .longOpt("all")
         .desc("Include all framework files regardless of tag.")
-        .build();
+        .get();
 
     private static final Options generalOptions = new Options();
     private static final Options decodeOptions = new Options();
@@ -457,18 +457,18 @@ public class Main {
             } else {
                 String mode = cli.getOptionValue(decodeResResolveModeOption);
                 switch (mode) {
-                    case "keep":
-                        config.setDecodeResolve(Config.DecodeResolve.KEEP);
+                    case "default":
+                        config.setDecodeResolve(Config.DecodeResolve.DEFAULT);
                         break;
-                    case "remove":
-                        config.setDecodeResolve(Config.DecodeResolve.REMOVE);
+                    case "greedy":
+                        config.setDecodeResolve(Config.DecodeResolve.GREEDY);
                         break;
-                    case "dummy":
-                        config.setDecodeResolve(Config.DecodeResolve.DUMMY);
+                    case "lazy":
+                        config.setDecodeResolve(Config.DecodeResolve.LAZY);
                         break;
                     default:
                         System.err.println("Unknown resolve resources mode: " + mode);
-                        System.err.println("Expect: 'keep', 'remove' or 'dummy'.");
+                        System.err.println("Expect: 'default', 'greedy' or 'lazy'.");
                         System.exit(1);
                         return;
                 }
@@ -711,6 +711,7 @@ public class Main {
         return sb.toString();
     }
 
+    @SuppressWarnings("deprecation")
     private static void printUsage() {
         PrintWriter writer = new PrintWriter(System.out);
         HelpFormatter formatter = new HelpFormatter();
@@ -773,6 +774,7 @@ public class Main {
         writer.flush();
     }
 
+    @SuppressWarnings("deprecation")
     private static void printOptions(PrintWriter writer, HelpFormatter formatter, Options options) {
         final int width = 120;
         final int leftPadding = 1;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/Config.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/Config.java
@@ -17,10 +17,10 @@
 package brut.androlib;
 
 public class Config {
-    public enum DecodeSources { NONE, FULL, ONLY_MAIN_CLASSES }
-    public enum DecodeResources { NONE, FULL, ONLY_MANIFEST }
-    public enum DecodeResolve { REMOVE, KEEP, DUMMY }
-    public enum DecodeAssets { NONE, FULL }
+    public enum DecodeSources { FULL, ONLY_MAIN_CLASSES, NONE }
+    public enum DecodeResources { FULL, ONLY_MANIFEST, NONE }
+    public enum DecodeResolve { DEFAULT, GREEDY, LAZY }
+    public enum DecodeAssets { FULL, NONE }
 
     private final String mVersion;
 
@@ -64,7 +64,7 @@ public class Config {
         mDecodeSources = DecodeSources.FULL;
         mBaksmaliDebugMode = true;
         mDecodeResources = DecodeResources.FULL;
-        mDecodeResolve = DecodeResolve.KEEP;
+        mDecodeResolve = DecodeResolve.DEFAULT;
         mKeepBrokenResources = false;
         mAnalysisMode = false;
         mDecodeAssets = DecodeAssets.FULL;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/BinaryResourceParser.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/BinaryResourceParser.java
@@ -270,7 +270,7 @@ public class BinaryResourceParser {
         }
 
         // Clean up.
-        injectMissingEntrySpecs();
+        injectDummyEntrySpecs();
         mInvalidConfigs.clear();
         mKeyStrings = null;
         mTypeStrings = null;
@@ -316,9 +316,10 @@ public class BinaryResourceParser {
             typeSpec = mPackage.addTypeSpec(id, mTypeStrings.getString(id - 1));
         }
 
+        String typeName = typeSpec.getName();
         ResType type;
         if (mInvalidConfigs.contains(config)) {
-            String dirName = typeSpec.getName() + config.getQualifiers();
+            String dirName = typeName + config.getQualifiers();
             if (mKeepBroken) {
                 LOGGER.warning("Invalid resource config detected: " + dirName);
                 type = mPackage.addType(id, config);
@@ -399,14 +400,14 @@ public class BinaryResourceParser {
             if (entryStart >= parser.chunkEnd()) {
                 LOGGER.warning(String.format(
                     "End of chunk hit. Skipping remaining %d entries in type: %s",
-                    entryCount, typeSpec.getName()));
+                    entryCount, typeName));
                 break;
             }
 
             // Align the stream with the start of the entry.
             mIn.jumpTo(entryStart);
 
-            Pair<Integer, ResValue> entry = parseEntry(typeSpec.getName());
+            Pair<Integer, ResValue> entry = parseEntry(typeName);
             int key = entry.getLeft();
             ResValue value = entry.getRight();
 
@@ -634,7 +635,7 @@ public class BinaryResourceParser {
         // Some apps store ID resource values generated for enum/flag items in attribute
         // resources as empty maps. Replace with a placeholder value.
         if (typeName.equals("id")) {
-            return new ResCustom("id");
+            return ResCustom.ID;
         }
 
         ResReference parent = new ResReference(mPackage, ResId.of(parentId));
@@ -683,7 +684,7 @@ public class BinaryResourceParser {
         // A resource reference is handled normally, unless it's @null.
         if (typeName.equals("id") && (data == 0 || (type != TypedValue.TYPE_REFERENCE
                 && type != TypedValue.TYPE_DYNAMIC_REFERENCE))) {
-            return new ResCustom("id");
+            return ResCustom.ID;
         }
 
         // Special handling for strings and file references.
@@ -805,19 +806,23 @@ public class BinaryResourceParser {
         }
     }
 
-    private void injectMissingEntrySpecs() throws AndrolibException {
-        if (mTable.getConfig().getDecodeResolve() == Config.DecodeResolve.DUMMY) {
+    private void injectDummyEntrySpecs() throws AndrolibException {
+        if (mTable.getConfig().getDecodeResolve() == Config.DecodeResolve.GREEDY) {
+            ResReference parent = new ResReference(mPackage, ResId.NULL);
+            ResBag.RawItem[] rawItems = new ResBag.RawItem[0];
+
             for (ResId id : mMissingEntrySpecs) {
                 ResTypeSpec typeSpec = mPackage.getTypeSpec(id.getTypeId());
+                String typeName = typeSpec.getName();
                 ResValue value;
-                switch (typeSpec.getName()) {
-                    case "attr":
-                    case "^attr-private":
-                        value = ResAttribute.DEFAULT;
-                        break;
-                    default:
-                        value = ResReference.NULL;
-                        break;
+                if (typeName.equals("id")) {
+                    value = ResCustom.ID;
+                } else if (typeName.equals("string")) {
+                    value = ResString.EMPTY;
+                } else if (typeSpec.isBagType()) {
+                    value = ResBag.parse(typeName, parent, rawItems);
+                } else {
+                    value = ResReference.NULL;
                 }
 
                 mPackage.addEntrySpec(id, ResEntrySpec.DUMMY_PREFIX + id);

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/BinaryXmlResourceParser.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/BinaryXmlResourceParser.java
@@ -401,12 +401,12 @@ public class BinaryXmlResourceParser implements XmlResourceParser {
         // Inject a generic spec for the attribute, otherwise we can't rebuild.
         if (nameId != ResId.NULL) {
             Config config = mTable.getConfig();
-            boolean removeUnresolved = config.getDecodeResolve() == Config.DecodeResolve.REMOVE;
+            boolean skipUnresolved = config.getDecodeResolve() == Config.DecodeResolve.LAZY;
             try {
                 ResPackage pkg = mTable.getMainPackage();
 
-                // #2836 - Skip item if the resource cannot be identified.
-                if (removeUnresolved || nameId.getPackageId() != pkg.getId()) {
+                // #2836 - Skip item if the resource cannot be resolved.
+                if (skipUnresolved || nameId.getPackageId() != pkg.getId()) {
                     LOGGER.warning(String.format(
                         "null attr reference: ns=%s, name=%s, id=%s",
                         getAttributePrefix(index), nameStr, nameId));
@@ -414,7 +414,7 @@ public class BinaryXmlResourceParser implements XmlResourceParser {
                 }
 
                 if (nameStr.isEmpty()) {
-                    nameStr = ResEntrySpec.MISSING_PREFIX + nameId;
+                    nameStr = ResEntrySpec.DUMMY_PREFIX + nameId;
                 }
                 nameStr = pkg.addEntrySpec(nameId, nameStr).getName();
                 pkg.addEntry(nameId, ResConfig.DEFAULT, ResAttribute.DEFAULT);

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/ResEntrySpec.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/ResEntrySpec.java
@@ -20,7 +20,6 @@ import java.util.Objects;
 
 public class ResEntrySpec {
     public static final String DUMMY_PREFIX = "APKTOOL_DUMMY_";
-    public static final String MISSING_PREFIX = "APKTOOL_MISSING_";
     public static final String RENAMED_PREFIX = "APKTOOL_RENAMED_";
 
     private final ResTypeSpec mTypeSpec;
@@ -85,18 +84,6 @@ public class ResEntrySpec {
     public String getFullName(boolean excludePackage, boolean excludeType) {
         return (excludePackage ? "" : getPackage().getName() + ":")
                 + (excludeType ? "" : getTypeName() + "/") + mName;
-    }
-
-    public boolean isDummy() {
-        return mName.startsWith(DUMMY_PREFIX);
-    }
-
-    public boolean isMissing() {
-        return mName.startsWith(MISSING_PREFIX);
-    }
-
-    public boolean isRenamed() {
-        return mName.startsWith(RENAMED_PREFIX);
     }
 
     @Override

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResArray.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResArray.java
@@ -53,17 +53,18 @@ public class ResArray extends ResBag implements ValuesXmlSerializable {
         // Since only string and integer arrays are supported,
         // it's safe to use the format as an array type.
         String format = resolveFormat();
-        String type = null;
         if (format != null) {
             switch (format) {
                 case "string":
                 case "integer":
-                    type = format;
+                    break;
+                default:
+                    format = null;
                     break;
             }
         }
 
-        String tagName = type != null ? type + "-array" : "array";
+        String tagName = (format != null ? format + "-" : "") + "array";
         serial.startTag(null, tagName);
         serial.attribute(null, "name", entry.getName());
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResAttribute.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResAttribute.java
@@ -231,7 +231,8 @@ public class ResAttribute extends ResBag implements ValuesXmlSerializable {
     @Override
     public void serializeToValuesXml(XmlSerializer serial, ResEntry entry)
             throws AndrolibException, IOException {
-        serial.startTag(null, "attr");
+        String tagName = "attr";
+        serial.startTag(null, tagName);
         serial.attribute(null, "name", entry.getName());
         String format = renderFormat();
         if (format != null) {
@@ -247,7 +248,7 @@ public class ResAttribute extends ResBag implements ValuesXmlSerializable {
             serial.attribute(null, "localization", "suggested");
         }
         serializeSymbolsToValuesXml(serial, entry);
-        serial.endTag(null, "attr");
+        serial.endTag(null, tagName);
     }
 
     private String renderFormat() {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResCustom.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResCustom.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.util.Objects;
 
 public class ResCustom extends ResValue implements ValuesXmlSerializable {
+    public static final ResCustom ID = new ResCustom("id");
+
     private final String mType;
     private final String mValue;
     private final boolean mAsItem;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResEnum.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResEnum.java
@@ -49,7 +49,7 @@ public class ResEnum extends ResAttribute {
     public void resolveKeys() throws AndrolibException {
         ResPackage pkg = mParent.getPackage();
         Config config = pkg.getTable().getConfig();
-        boolean removeUnresolved = config.getDecodeResolve() == Config.DecodeResolve.REMOVE;
+        boolean skipUnresolved = config.getDecodeResolve() == Config.DecodeResolve.LAZY;
 
         for (Symbol symbol : mSymbols) {
             ResReference key = symbol.getKey();
@@ -59,15 +59,15 @@ public class ResEnum extends ResAttribute {
 
             ResId entryId = key.getId();
 
-            // #2836 - Skip item if the resource cannot be identified.
-            if (removeUnresolved || entryId.getPackageId() != pkg.getId()) {
+            // #2836 - Skip item if the resource cannot be resolved.
+            if (skipUnresolved || entryId.getPackageId() != pkg.getId()) {
                 LOGGER.warning(String.format(
                     "null enum reference: key=%s, value=%s", key, symbol.getValue()));
                 continue;
             }
 
-            pkg.addEntrySpec(entryId, ResEntrySpec.MISSING_PREFIX + entryId);
-            pkg.addEntry(entryId, ResConfig.DEFAULT, new ResCustom("id"));
+            pkg.addEntrySpec(entryId, ResEntrySpec.DUMMY_PREFIX + entryId);
+            pkg.addEntry(entryId, ResConfig.DEFAULT, ResCustom.ID);
         }
     }
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResFlags.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResFlags.java
@@ -51,7 +51,7 @@ public class ResFlags extends ResAttribute {
     public void resolveKeys() throws AndrolibException {
         ResPackage pkg = mParent.getPackage();
         Config config = pkg.getTable().getConfig();
-        boolean removeUnresolved = config.getDecodeResolve() == Config.DecodeResolve.REMOVE;
+        boolean skipUnresolved = config.getDecodeResolve() == Config.DecodeResolve.LAZY;
 
         for (Symbol symbol : mSymbols) {
             ResReference key = symbol.getKey();
@@ -61,15 +61,15 @@ public class ResFlags extends ResAttribute {
 
             ResId entryId = key.getId();
 
-            // #2836 - Skip item if the resource cannot be identified.
-            if (removeUnresolved || entryId.getPackageId() != pkg.getId()) {
+            // #2836 - Skip item if the resource cannot be resolved.
+            if (skipUnresolved || entryId.getPackageId() != pkg.getId()) {
                 LOGGER.warning(String.format(
                     "null flag reference: key=%s, value=%s", key, symbol.getValue()));
                 continue;
             }
 
-            pkg.addEntrySpec(entryId, ResEntrySpec.MISSING_PREFIX + entryId);
-            pkg.addEntry(entryId, ResConfig.DEFAULT, new ResCustom("id"));
+            pkg.addEntrySpec(entryId, ResEntrySpec.DUMMY_PREFIX + entryId);
+            pkg.addEntry(entryId, ResConfig.DEFAULT, ResCustom.ID);
         }
     }
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResItem.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResItem.java
@@ -47,16 +47,18 @@ public abstract class ResItem extends ResValue {
                 return data == TypedValue.DATA_NULL_EMPTY ? ResPrimitive.EMPTY : ResReference.NULL;
             case TypedValue.TYPE_REFERENCE:
             case TypedValue.TYPE_DYNAMIC_REFERENCE:
-                return (data != 0 || rawValue != null)
+                return (data != 0 || (rawValue != null && !rawValue.isEmpty()))
                     ? new ResReference(pkg, ResId.of(data), rawValue)
                     : ResReference.NULL;
             case TypedValue.TYPE_ATTRIBUTE:
             case TypedValue.TYPE_DYNAMIC_ATTRIBUTE:
-                return (data != 0 || rawValue != null)
+                return (data != 0 || (rawValue != null && !rawValue.isEmpty()))
                     ? new ResReference(pkg, ResId.of(data), rawValue, ResReference.Type.ATTRIBUTE)
                     : ResReference.NULL;
             case TypedValue.TYPE_STRING:
-                return new ResString(rawValue);
+                return (rawValue != null && !rawValue.isEmpty())
+                    ? new ResString(rawValue)
+                    : ResString.EMPTY;
             case TypedValue.TYPE_FLOAT:
             case TypedValue.TYPE_DIMENSION:
             case TypedValue.TYPE_FRACTION:

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResPlural.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResPlural.java
@@ -51,7 +51,8 @@ public class ResPlural extends ResBag implements ValuesXmlSerializable {
     @Override
     public void serializeToValuesXml(XmlSerializer serial, ResEntry entry)
             throws AndrolibException, IOException {
-        serial.startTag(null, "plurals");
+        String tagName = "plurals";
+        serial.startTag(null, tagName);
         serial.attribute(null, "name", entry.getName());
 
         for (RawItem item : mItems) {
@@ -99,7 +100,7 @@ public class ResPlural extends ResBag implements ValuesXmlSerializable {
             serial.endTag(null, "item");
         }
 
-        serial.endTag(null, "plurals");
+        serial.endTag(null, tagName);
     }
 
     @Override

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResPrimitive.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResPrimitive.java
@@ -61,17 +61,16 @@ public class ResPrimitive extends ResItem implements ResXmlEncodable, ValuesXmlS
     public void serializeToValuesXml(XmlSerializer serial, ResEntry entry)
             throws AndrolibException, IOException {
         String type = entry.getTypeName();
-        boolean asItem = entry.getSpec().isDummy();
 
         // Specify format for <item> tags when the resource type doesn't
         // directly support this primitive format.
         String format = getFormat();
-        Set<String> standardFormats = STANDARD_TYPE_FORMATS.get(type);
-        boolean needsFormat;
-        if (format != null && standardFormats != null && standardFormats.contains(format)) {
-            needsFormat = false;
+        boolean asItem;
+        if (format != null) {
+            Set<String> standardFormats = STANDARD_TYPE_FORMATS.get(type);
+            asItem = standardFormats == null || !standardFormats.contains(format);
         } else {
-            needsFormat = asItem = true;
+            asItem = false;
         }
 
         String tagName = asItem ? "item" : type;
@@ -80,7 +79,7 @@ public class ResPrimitive extends ResItem implements ResXmlEncodable, ValuesXmlS
             serial.attribute(null, "type", type);
         }
         serial.attribute(null, "name", entry.getName());
-        if (needsFormat) {
+        if (asItem) {
             serial.attribute(null, "format", format);
         }
         serial.text(encodeAsResXmlValue());

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResReference.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResReference.java
@@ -110,13 +110,15 @@ public class ResReference extends ResItem implements ResXmlEncodable, ValuesXmlS
     public void serializeToValuesXml(XmlSerializer serial, ResEntry entry)
             throws AndrolibException, IOException {
         String type = entry.getTypeName();
-        boolean asItem = entry.getSpec().isDummy();
 
         // A bag type with a reference value must be an <item> tag.
         // Otherwise, when the decoded app is rebuilt, the reference will be lost.
-        if (entry.getType().isBagType()) {
-            asItem = true;
-        }
+        boolean asItem = entry.getType().isBagType();
+
+        // Only set body if not @null or the entry is a <string> tag.
+        // @null is the default value for all item types except string.
+        // Note: We never set @null to <id> tags.
+        boolean needsBody = resolve() != null || type.equals("string");
 
         String tagName = asItem ? "item" : type;
         serial.startTag(null, tagName);
@@ -124,7 +126,9 @@ public class ResReference extends ResItem implements ResXmlEncodable, ValuesXmlS
             serial.attribute(null, "type", type);
         }
         serial.attribute(null, "name", entry.getName());
-        serial.text(encodeAsResXmlValue());
+        if (needsBody) {
+            serial.text(encodeAsResXmlValue());
+        }
         serial.endTag(null, tagName);
     }
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResString.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResString.java
@@ -29,6 +29,8 @@ import java.util.Objects;
 import java.util.Set;
 
 public class ResString extends ResItem implements ResXmlEncodable, ValuesXmlSerializable {
+    public static final ResString EMPTY = new ResString("");
+
     private final String mValue;
 
     public ResString(String text) {
@@ -65,17 +67,11 @@ public class ResString extends ResItem implements ResXmlEncodable, ValuesXmlSeri
     public void serializeToValuesXml(XmlSerializer serial, ResEntry entry)
             throws AndrolibException, IOException {
         String type = entry.getTypeName();
-        boolean asItem = entry.getSpec().isDummy();
 
         // Specify format for <item> tags when the resource type doesn't
         // directly support the string format.
         Set<String> standardFormats = STANDARD_TYPE_FORMATS.get(type);
-        boolean needsFormat;
-        if (standardFormats != null && standardFormats.contains("string")) {
-            needsFormat = false;
-        } else {
-            needsFormat = asItem = true;
-        }
+        boolean asItem = standardFormats == null || !standardFormats.contains("string");
 
         String tagName = asItem ? "item" : type;
         serial.startTag(null, tagName);
@@ -83,7 +79,7 @@ public class ResString extends ResItem implements ResXmlEncodable, ValuesXmlSeri
             serial.attribute(null, "type", type);
         }
         serial.attribute(null, "name", entry.getName());
-        if (needsFormat) {
+        if (asItem) {
             serial.attribute(null, "format", "string");
         }
         if (!asItem && hasMultipleNonPositionalSubstitutions()) {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResStyle.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResStyle.java
@@ -83,7 +83,7 @@ public class ResStyle extends ResBag implements ValuesXmlSerializable {
     public void resolveKeys() throws AndrolibException {
         ResPackage pkg = mParent.getPackage();
         Config config = pkg.getTable().getConfig();
-        boolean removeUnresolved = config.getDecodeResolve() == Config.DecodeResolve.REMOVE;
+        boolean skipUnresolved = config.getDecodeResolve() == Config.DecodeResolve.LAZY;
 
         for (Item item : mItems) {
             ResReference key = item.getKey();
@@ -98,15 +98,15 @@ public class ResStyle extends ResBag implements ValuesXmlSerializable {
 
             ResId entryId = key.getId();
 
-            // #2836 - Skip item if the resource cannot be identified.
-            if (removeUnresolved || entryId.getPackageId() != pkg.getId()) {
+            // #2836 - Skip item if the resource cannot be resolved.
+            if (skipUnresolved || entryId.getPackageId() != pkg.getId()) {
                 LOGGER.warning(String.format(
                     "null style reference: key=%s, value=%s", key, item.getValue()));
                 continue;
             }
 
             if (keySpec == null) {
-                pkg.addEntrySpec(entryId, ResEntrySpec.MISSING_PREFIX + entryId);
+                pkg.addEntrySpec(entryId, ResEntrySpec.DUMMY_PREFIX + entryId);
             }
             pkg.addEntry(entryId, ResConfig.DEFAULT, ResAttribute.DEFAULT);
         }
@@ -115,7 +115,8 @@ public class ResStyle extends ResBag implements ValuesXmlSerializable {
     @Override
     public void serializeToValuesXml(XmlSerializer serial, ResEntry entry)
             throws AndrolibException, IOException {
-        serial.startTag(null, "style");
+        String tagName = "style";
+        serial.startTag(null, tagName);
         serial.attribute(null, "name", entry.getName());
         if (mParent.resolve() != null) {
             serial.attribute(null, "parent", mParent.encodeAsResXmlAttrValue());
@@ -167,7 +168,7 @@ public class ResStyle extends ResBag implements ValuesXmlSerializable {
             processedNames.add(keyName);
         }
 
-        serial.endTag(null, "style");
+        serial.endTag(null, tagName);
     }
 
     @Override

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/AndResGuardTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/AndResGuardTest.java
@@ -47,7 +47,7 @@ public class AndResGuardTest extends BaseTest {
         sConfig.setDecodeResources(Config.DecodeResources.NONE);
 
         ExtFile testApk = new ExtFile(sTmpDir, TEST_APK);
-        ExtFile testDir = new ExtFile(testApk + ".raw.out");
+        ExtFile testDir = new ExtFile(testApk + ".out.raw");
         new ApkDecoder(testApk, sConfig).decode(testDir);
 
         assertTrue(new File(testDir, "r/a/a.png").isFile());

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/DecodeResolveTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/DecodeResolveTest.java
@@ -34,11 +34,54 @@ public class DecodeResolveTest extends BaseTest {
     }
 
     @Test
-    public void decodeResolveRemoveTest() throws BrutException {
-        sConfig.setDecodeResolve(Config.DecodeResolve.REMOVE);
+    public void decodeResolveDefaultTest() throws BrutException {
+        sConfig.setDecodeResolve(Config.DecodeResolve.DEFAULT);
 
         ExtFile testApk = new ExtFile(sTmpDir, TEST_APK);
-        ExtFile testDir = new ExtFile(testApk + ".out.remove");
+        ExtFile testDir = new ExtFile(testApk + ".out.default");
+        new ApkDecoder(testApk, sConfig).decode(testDir);
+
+        assertTrue(new File(testDir, "res/values/strings.xml").isFile());
+
+        Document attrDocument = loadDocument(new File(testDir, "res/values/attrs.xml"));
+        assertEquals(4, attrDocument.getElementsByTagName("enum").getLength());
+
+        Document colorDocument = loadDocument(new File(testDir, "res/values/colors.xml"));
+        assertEquals(8, colorDocument.getElementsByTagName("color").getLength());
+
+        Document publicDocument = loadDocument(new File(testDir, "res/values/public.xml"));
+        assertEquals(22, publicDocument.getElementsByTagName("public").getLength());
+    }
+
+    @Test
+    public void decodeResolveGreedyTest() throws BrutException {
+        sConfig.setDecodeResolve(Config.DecodeResolve.GREEDY);
+
+        ExtFile testApk = new ExtFile(sTmpDir, TEST_APK);
+        ExtFile testDir = new ExtFile(testApk + ".out.greedy");
+        new ApkDecoder(testApk, sConfig).decode(testDir);
+
+        assertTrue(new File(testDir, "res/values/strings.xml").isFile());
+
+        File attrXml = new File(testDir, "res/values/attrs.xml");
+        Document attrDocument = loadDocument(attrXml);
+        assertEquals(4, attrDocument.getElementsByTagName("enum").getLength());
+
+        File colorXml = new File(testDir, "res/values/colors.xml");
+        Document colorDocument = loadDocument(colorXml);
+        assertEquals(9, colorDocument.getElementsByTagName("color").getLength());
+
+        File publicXml = new File(testDir, "res/values/public.xml");
+        Document publicDocument = loadDocument(publicXml);
+        assertEquals(23, publicDocument.getElementsByTagName("public").getLength());
+    }
+
+    @Test
+    public void decodeResolveLazyTest() throws BrutException {
+        sConfig.setDecodeResolve(Config.DecodeResolve.LAZY);
+
+        ExtFile testApk = new ExtFile(sTmpDir, TEST_APK);
+        ExtFile testDir = new ExtFile(testApk + ".out.lazy");
         new ApkDecoder(testApk, sConfig).decode(testDir);
 
         assertTrue(new File(testDir, "res/values/strings.xml").isFile());
@@ -50,55 +93,9 @@ public class DecodeResolveTest extends BaseTest {
         File colorXml = new File(testDir, "res/values/colors.xml");
         Document colorDocument = loadDocument(colorXml);
         assertEquals(8, colorDocument.getElementsByTagName("color").getLength());
-        assertEquals(0, colorDocument.getElementsByTagName("item").getLength());
 
         File publicXml = new File(testDir, "res/values/public.xml");
         Document publicDocument = loadDocument(publicXml);
         assertEquals(21, publicDocument.getElementsByTagName("public").getLength());
-    }
-
-    @Test
-    public void decodeResolveKeepTest() throws BrutException {
-        sConfig.setDecodeResolve(Config.DecodeResolve.KEEP);
-
-        ExtFile testApk = new ExtFile(sTmpDir, TEST_APK);
-        ExtFile testDir = new ExtFile(testApk + ".out.leave");
-        new ApkDecoder(testApk, sConfig).decode(testDir);
-
-        assertTrue(new File(testDir, "res/values/strings.xml").isFile());
-
-        Document attrDocument = loadDocument(new File(testDir, "res/values/attrs.xml"));
-        assertEquals(4, attrDocument.getElementsByTagName("enum").getLength());
-
-        Document colorDocument = loadDocument(new File(testDir, "res/values/colors.xml"));
-        assertEquals(8, colorDocument.getElementsByTagName("color").getLength());
-        assertEquals(0, colorDocument.getElementsByTagName("item").getLength());
-
-        Document publicDocument = loadDocument(new File(testDir, "res/values/public.xml"));
-        assertEquals(22, publicDocument.getElementsByTagName("public").getLength());
-    }
-
-    @Test
-    public void decodeResolveDummyTest() throws BrutException {
-        sConfig.setDecodeResolve(Config.DecodeResolve.DUMMY);
-
-        ExtFile testApk = new ExtFile(sTmpDir, TEST_APK);
-        ExtFile testDir = new ExtFile(testApk + ".out.dummies");
-        new ApkDecoder(testApk, sConfig).decode(testDir);
-
-        assertTrue(new File(testDir, "res/values/strings.xml").isFile());
-
-        File attrXml = new File(testDir, "res/values/attrs.xml");
-        Document attrDocument = loadDocument(attrXml);
-        assertEquals(4, attrDocument.getElementsByTagName("enum").getLength());
-
-        File colorXml = new File(testDir, "res/values/colors.xml");
-        Document colorDocument = loadDocument(colorXml);
-        assertEquals(8, colorDocument.getElementsByTagName("color").getLength());
-        assertEquals(1, colorDocument.getElementsByTagName("item").getLength());
-
-        File publicXml = new File(testDir, "res/values/public.xml");
-        Document publicDocument = loadDocument(publicXml);
-        assertEquals(23, publicDocument.getElementsByTagName("public").getLength());
     }
 }

--- a/brut.apktool/apktool-lib/src/test/resources/testapp/res/values-mcc001/anims.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/testapp/res/values-mcc001/anims.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <anim name="test_anims1">@android:anim/bounce_interpolator</anim>
-    <anim name="test_anims2">@android:anim/cycle_interpolator</anim>
-    <anim name="test_anims3">@android:anim/decelerate_interpolator</anim>
-    <anim name="test_anims4">@android:anim/fade_in</anim>
-    <anim name="test_anims5">@android:anim/fade_out</anim>
-    <anim name="test_anims6">@android:anim/linear_interpolator</anim>
-    <anim name="test_anims7">@android:anim/overshoot_interpolator</anim>
-    <anim name="test_anims8">@android:anim/slide_in_left</anim>
-    <anim name="test_anims9">@android:anim/slide_out_right</anim>
+    <anim name="test_anim0" />
+    <anim name="test_anim1">@android:anim/bounce_interpolator</anim>
+    <anim name="test_anim2">@android:anim/cycle_interpolator</anim>
+    <anim name="test_anim3">@android:anim/decelerate_interpolator</anim>
+    <anim name="test_anim4">@android:anim/fade_in</anim>
+    <anim name="test_anim5">@android:anim/fade_out</anim>
+    <anim name="test_anim6">@android:anim/linear_interpolator</anim>
+    <anim name="test_anim7">@android:anim/overshoot_interpolator</anim>
+    <anim name="test_anim8">@android:anim/slide_in_left</anim>
+    <anim name="test_anim9">@android:anim/slide_out_right</anim>
 </resources>

--- a/brut.apktool/apktool-lib/src/test/resources/testapp/res/values-mcc001/arrays.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/testapp/res/values-mcc001/arrays.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <array name="test_array0" />
     <string-array name="test_array1">
         <item>TEST1</item>
         <item>TEST2</item>

--- a/brut.apktool/apktool-lib/src/test/resources/testapp/res/values-mcc001/bools.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/testapp/res/values-mcc001/bools.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <bool name="test_bool0" />
     <bool name="test_bool1">false</bool>
     <bool name="test_bool2">true</bool>
 </resources>

--- a/brut.apktool/apktool-lib/src/test/resources/testapp/res/values-mcc001/colors.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/testapp/res/values-mcc001/colors.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <color name="test_color0" />
     <color name="test_color1">#ff123456</color>
     <color name="test_color2">@android:color/white</color>
     <color name="test_color3">#00000000</color>

--- a/brut.apktool/apktool-lib/src/test/resources/testapp/res/values-mcc001/dimens.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/testapp/res/values-mcc001/dimens.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <dimen name="test_dimen0" />
     <dimen name="test_dimen1">10.0dp</dimen>
     <dimen name="test_dimen2">10.0sp</dimen>
     <dimen name="test_dimen3">10.0pt</dimen>

--- a/brut.apktool/apktool-lib/src/test/resources/testapp/res/values-mcc001/drawables.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/testapp/res/values-mcc001/drawables.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <drawable name="test_drawable0" />
     <drawable name="test_drawable1">@android:drawable/btn_default</drawable>
     <drawable name="test_drawable2">@drawable/ic_launcher</drawable>
-    <drawable name="test_drawable3">@null</drawable>
-    <drawable name="test_drawable4">#00000000</drawable>
+    <drawable name="test_drawable3">#00000000</drawable>
 </resources>

--- a/brut.apktool/apktool-lib/src/test/resources/testapp/res/values-mcc001/integers.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/testapp/res/values-mcc001/integers.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <integer name="test_integer0" />
     <integer name="test_integer1">-1</integer>
     <integer name="test_integer2">0</integer>
     <integer name="test_integer3">1</integer>

--- a/brut.apktool/apktool-lib/src/test/resources/testapp/res/values-mcc001/layouts.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/testapp/res/values-mcc001/layouts.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <layout name="test_layouts1">@android:layout/activity_list_item</layout>
-    <layout name="test_layouts2">@android:layout/browser_link_context_header</layout>
-    <layout name="test_layouts3">@android:layout/simple_list_item_1</layout>
-    <layout name="test_layouts4">@android:layout/simple_spinner_item</layout>
+    <layout name="test_layout0" />
+    <layout name="test_layout1">@android:layout/activity_list_item</layout>
+    <layout name="test_layout2">@android:layout/browser_link_context_header</layout>
+    <layout name="test_layout3">@android:layout/simple_list_item_1</layout>
+    <layout name="test_layout4">@android:layout/simple_spinner_item</layout>
 </resources>

--- a/brut.apktool/apktool-lib/src/test/resources/testapp/res/values-mcc001/plurals.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/testapp/res/values-mcc001/plurals.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <plurals name="test_plurals0" />
     <plurals name="test_plurals1">
         <item quantity="one">%1$s, %2$d foo</item>
         <item quantity="other">%1$s, %2$d foo(s)</item>

--- a/brut.apktool/apktool-lib/src/test/resources/testapp/res/values-mcc001/strings.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/testapp/res/values-mcc001/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="test_string1"></string>
+    <string name="test_string0" />
+    <string name="test_string1">@null</string>
     <string name="test_string2">Lorem ipsum...</string>
     <string name="test_string3">\@</string>
     <string name="test_string4">\?</string>

--- a/brut.apktool/apktool-lib/src/test/resources/testapp/res/values/attrs.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/testapp/res/values/attrs.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <attr name="test_attr0"/>
     <attr format="integer" name="test_attr1"/>
     <attr format="reference" name="test_attr2"/>
     <attr format="reference" name="test_attr3"/>

--- a/brut.apktool/apktool-lib/src/test/resources/testapp/res/values/colors.xml
+++ b/brut.apktool/apktool-lib/src/test/resources/testapp/res/values/colors.xml
@@ -6,5 +6,5 @@
     <color name="test_color4">#c1ac1a</color>
     <color name="test_color5">#abcd</color>
     <color name="test_color6">#123</color>
-    <color name="issue_3416">@null</color>
+    <item type="color" name="issue_3416" format="string">\@null</item>
 </resources>


### PR DESCRIPTION
* Since `--res-resolve-mode` has a new name in 3.x we can afford to update the modes to better describe their meaning.

- `default`: Adds dummy entries only for resources that cannot be resolved.
  (this is done after ARSC parsing, during resolution and res file decoding stages)
- `greedy`: Adds dummy entries for all missing resources in the resource table.
  (this is done during ARSC parsing, at the end of each package)
- `lazy`: Ignores resources that are missing or cannot be resolved.

(Docs will be updated after merge.)

* `APKTOOL_MISSING_` is now also `APKTOOL_DUMMY_` (they are the same thing, just were added at different stages).

* Improve dummy serialization based on each item/bag type's default value.

Case study:
```xml
<resources>
    <anim name="DUMMY" />
    <animator name="DUMMY" />
    <array name="DUMMY" />
    <attr name="DUMMY" />
    <bool name="DUMMY" />
    <color name="DUMMY" />
    <dimen name="DUMMY" />
    <drawable name="DUMMY" />
    <font name="DUMMY" />
    <fraction name="DUMMY" />
    <id name="DUMMY" />
    <integer name="DUMMY" />
    <interpolator name="DUMMY" />
    <layout name="DUMMY" />
    <menu name="DUMMY" />
    <mipmap name="DUMMY" />
    <plurals name="DUMMY" />
    <raw name="DUMMY" />
    <string name="DUMMY" />
    <style name="DUMMY" />
    <transition name="DUMMY" />
    <xml name="DUMMY" />
</resources>
```

aapt2 dump resources:
```
type anim id=01 entryCount=1
  resource 0x7f010000 anim/DUMMY
    () @null
type animator id=02 entryCount=1
  resource 0x7f020000 animator/DUMMY
    () @null
type array id=03 entryCount=1
  resource 0x7f030000 array/DUMMY
    () (array) size=0
      []
type attr id=04 entryCount=1
  resource 0x7f040000 attr/DUMMY
    () (attr) type=any
type bool id=05 entryCount=1
  resource 0x7f050000 bool/DUMMY
    () @null
type color id=06 entryCount=1
  resource 0x7f060000 color/DUMMY
    () @null
type dimen id=07 entryCount=1
  resource 0x7f070000 dimen/DUMMY
    () @null
type drawable id=08 entryCount=1
  resource 0x7f080000 drawable/DUMMY
    () @null
type font id=09 entryCount=1
  resource 0x7f090000 font/DUMMY
    () @null
type fraction id=0a entryCount=1
  resource 0x7f0a0000 fraction/DUMMY
    () @null
type id id=0b entryCount=1
  resource 0x7f0b0000 id/DUMMY
    () (id)
type integer id=0c entryCount=1
  resource 0x7f0c0000 integer/DUMMY
    () @null
type interpolator id=0d entryCount=1
  resource 0x7f0d0000 interpolator/DUMMY
    () @null
type layout id=0e entryCount=1
  resource 0x7f0e0000 layout/DUMMY
    () @null
type menu id=0f entryCount=1
  resource 0x7f0f0000 menu/DUMMY
    () @null
type mipmap id=10 entryCount=1
  resource 0x7f100000 mipmap/DUMMY
    () @null
type plurals id=11 entryCount=1
  resource 0x7f110000 plurals/DUMMY
    () (plurals) size=0
type raw id=12 entryCount=1
  resource 0x7f120000 raw/DUMMY
    () @null
type string id=13 entryCount=1
  resource 0x7f130000 string/DUMMY
    () ""
type style id=14 entryCount=1
  resource 0x7f140000 style/DUMMY
    () (style) size=0
type transition id=15 entryCount=1
  resource 0x7f150000 transition/DUMMY
    () @null
type xml id=16 entryCount=1
  resource 0x7f160000 xml/DUMMY
    () @null
```

We learn that:
- default value for bag types (`array`, `attr`, `plurals`, `style`) is an empty bag of the given type.
- default value for `id` type is a special placeholder (we already handled that).
- default value for `string` type is the empty string ("").
- default value for the rest of the item types is `@null`.

Use that to serialize them accordingly and add dummies with the appropriate default value.
The result is avoiding unnecessary `<item>` tags and unnecessary `@null`s where empty tags mean the same.
Much cleaner output, `<item>` tags are used only when it's unavoidable.

Also added a few test cases for this.