### PR TITLE
fix: handle arbitrary resources

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
@@ -302,10 +302,17 @@ public class ApkDecoder {
         try {
             Map<String, String> resFileMapping = mResDecoder.getResFileMapping();
             Directory in = mApkFile.getDirectory();
+            boolean hasResTable = mApkInfo.hasResources();
 
             for (String fileName : in.getFiles(true)) {
-                if (!ApkInfo.STANDARD_FILENAMES_PATTERN.matcher(fileName).matches()
-                        && !resFileMapping.containsKey(fileName)) {
+                boolean isStandard = ApkInfo.STANDARD_FILENAMES_PATTERN.matcher(fileName).matches();
+
+                // Handle arbitrary resources
+                if (!hasResTable && fileName.startsWith("res/")) {
+                    isStandard = false;
+                }
+
+                if (!isStandard && !resFileMapping.containsKey(fileName)) {
                     in.copyToDir(unknownDir, fileName);
                 }
             }


### PR DESCRIPTION
Fixes: #3615 

This fixes resources not being handled if a resource table could not be found, as is currently the case for `framework.jar` files.

The issue is caused by  `decodeResources` (rightfully) skipping decoding if no `resources.arsc` was found, but as `copyUnknownFiles` ignores resources expecting they would be handled by this method, they ultimately just end up being left out. Therefore, this patch adds an extra check in `copyUnknownFiles` to copy resources as-is if no resource table was found.