### PR TITLE
chore: promote -a/--all-src to a common option

### DIFF
--- a/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
+++ b/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
@@ -231,6 +231,7 @@ public class Main {
         generalOptions.addOption(verboseOption);
 
         if (options == null || options == decodeOptions) {
+            decodeOptions.addOption(decodeAllSrcOption);
             decodeOptions.addOption(decodeForceOption);
             decodeOptions.addOption(decodeNoResOption);
             decodeOptions.addOption(decodeNoSrcOption);
@@ -240,7 +241,6 @@ public class Main {
             decodeOptions.addOption(jobsOption);
             decodeOptions.addOption(libOption);
             if (advanced) {
-                decodeOptions.addOption(decodeAllSrcOption);
                 decodeOptions.addOption(decodeKeepBrokenResOption);
                 decodeOptions.addOption(decodeMatchOriginalOption);
                 decodeOptions.addOption(decodeNoAssetsOption);


### PR DESCRIPTION
The `-a`/`--all-src` has a short option, can be promoted to a common option rather than advanced one.
Totally escaped my mind.