### PR TITLE
feat: support multi-dex containers

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
@@ -129,13 +129,9 @@ public class ApkDecoder {
 
                 if (noSrc) {
                     copySourcesRaw(outDir, fileName);
-                    continue;
+                } else {
+                    decodeSourcesSmali(outDir, fileName);
                 }
-
-                String dirName = "smali" + (!fileName.equals("classes.dex")
-                    ? "_" + fileName.substring(0, fileName.lastIndexOf('.')).replace(in.separatorChar, '@') : "");
-
-                decodeSourcesSmali(new File(outDir, dirName), fileName);
             }
         } catch (DirectoryException ex) {
             throw new AndrolibException(ex);


### PR DESCRIPTION
* Preload the APK file as a `ZipDexContainer` once per `SmaliDecoder` instance and reuse it for all `decode` calls.
* Defer smali folder naming. `SmaliDecoder` will decide folder naming based on whether a dex file is a multi-dex container or not.
* If a dex file is a multi-dex container, each contained dex file will be decoded to a separate smali folder.
* Since `smali` support for dex version 041 is limited, building smali folders decoded from a multi-dex container will produce separate dex 039 files instead.