### PR TITLE
Handle preloaded library APKs during decode

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/Config.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/Config.java
@@ -16,6 +16,13 @@
  */
 package brut.androlib;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+
 public class Config {
     public enum DecodeSources { FULL, ONLY_MAIN_CLASSES, NONE }
     public enum DecodeResources { FULL, ONLY_MANIFEST, NONE }
@@ -116,6 +123,39 @@ public class Config {
 
     public void setLibraryFiles(String[] libraryFiles) {
         mLibraryFiles = libraryFiles;
+    }
+
+    public boolean hasLibraryFiles() {
+        return mLibraryFiles != null && mLibraryFiles.length > 0;
+    }
+
+    public Map<String, File> getLibraryApkFileMap() {
+        Map<String, File> apkFiles = new LinkedHashMap<>();
+        if (!hasLibraryFiles()) {
+            return apkFiles;
+        }
+
+        for (String libEntry : mLibraryFiles) {
+            String[] parts = libEntry.split(":", 2);
+            if (parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty()) {
+                continue;
+            }
+
+            apkFiles.putIfAbsent(parts[0], new File(parts[1]));
+        }
+        return apkFiles;
+    }
+
+    public Collection<File> getUniqueLibraryApkFiles() {
+        Collection<File> files = new ArrayList<>();
+        LinkedHashSet<String> seenPaths = new LinkedHashSet<>();
+        for (File apkFile : getLibraryApkFileMap().values()) {
+            String apkPath = apkFile.getAbsolutePath();
+            if (seenPaths.add(apkPath)) {
+                files.add(apkFile);
+            }
+        }
+        return files;
     }
 
     public boolean isForced() {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AaptInvoker.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AaptInvoker.java
@@ -201,18 +201,9 @@ public class AaptInvoker {
 
         List<String> usesLibrary = mApkInfo.getUsesLibrary();
         if (!usesLibrary.isEmpty()) {
-            String[] libFiles = mConfig.getLibraryFiles();
+            Map<String, File> libraryApkFiles = mConfig.getLibraryApkFileMap();
             for (String name : usesLibrary) {
-                File libFile = null;
-                if (libFiles != null) {
-                    for (String libEntry : libFiles) {
-                        String[] parts = libEntry.split(":", 2);
-                        if (parts.length == 2 && name.equals(parts[0])) {
-                            libFile = new File(parts[1]);
-                            break;
-                        }
-                    }
-                }
+                File libFile = libraryApkFiles.get(name);
                 if (libFile != null) {
                     files.add(libFile);
                 } else {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/ResDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/ResDecoder.java
@@ -92,14 +92,14 @@ public class ResDecoder {
         ResPackage pkg = mTable.getMainPackage();
 
         Log.i(TAG, "Decoding value resources...");
-        for (ResEntry entry : Lists.newArrayList(pkg.getGroup().listEntries())) {
+        for (ResEntry entry : Lists.newArrayList(getDecodeEntries(pkg))) {
             if (entry.getValue() instanceof ResBag) {
                 ((ResBag) entry.getValue()).resolveKeys();
             }
         }
 
         Log.i(TAG, "Decoding file resources...");
-        for (ResEntry entry : Lists.newArrayList(pkg.getGroup().listEntries())) {
+        for (ResEntry entry : Lists.newArrayList(getDecodeEntries(pkg))) {
             if (entry.getValue() instanceof ResFileReference) {
                 fileDecoder.decode(entry, inDir, outDir, mResFileMap);
             }
@@ -122,9 +122,10 @@ public class ResDecoder {
 
     private void generateValuesXmls(ResPackage pkg, Directory outDir, ResXmlSerializer serial)
             throws AndrolibException {
-        // Group entries by type name + qualifiers, ignoring alias duplicates in sub-packages.
+        // Group entries by type name + qualifiers. When library APKs are preloaded for reference
+        // resolution, keep the generated values scoped to the main decoded package only.
         Map<Pair<String, String>, List<ResEntry>> entriesMap = new HashMap<>();
-        for (ResEntry entry : pkg.getGroup().listEntries()) {
+        for (ResEntry entry : getDecodeEntries(pkg)) {
             if (entry.getValue() instanceof ValuesXmlSerializable && !pkg.isAlias(entry.getResId())) {
                 ResType type = entry.getType();
                 Pair<String, String> key = Pair.of(type.getName(), type.getConfig().toQualifiers());
@@ -189,7 +190,7 @@ public class ResDecoder {
 
     private void generateStagingXmls(ResPackage pkg, Directory outDir, ResXmlSerializer serial)
             throws AndrolibException {
-        if (pkg.getGroup().getPackageCount() <= 1) {
+        if (pkg.getGroup().getPackageCount() <= 1 || isDecodingWithLibraryApks()) {
             return;
         }
 
@@ -299,6 +300,14 @@ public class ResDecoder {
                 throw new AndrolibException("Could not generate: " + outFileName, ex);
             }
         }
+    }
+
+    private Iterable<ResEntry> getDecodeEntries(ResPackage pkg) {
+        return isDecodingWithLibraryApks() ? pkg.listEntries() : pkg.getGroup().listEntries();
+    }
+
+    private boolean isDecodingWithLibraryApks() {
+        return mConfig.hasLibraryFiles();
     }
 
     private void generateOverlayableXml(ResPackage pkg, Directory outDir, ResXmlSerializer serial)
@@ -431,14 +440,25 @@ public class ResDecoder {
                 usesFramework.setTag(mConfig.getFrameworkTag());
             }
 
-            // Record library package names used by the resource table.
+            // Record library package names used by the resource table. If library APKs were
+            // preloaded explicitly for decode-time reference resolution, preserve those names so
+            // the same includes can be passed back to aapt2 during rebuild.
+            LinkedHashSet<String> usesLibrary = new LinkedHashSet<>(mApkInfo.getUsesLibrary());
+
             List<Integer> libPackageIds = Lists.newArrayList(mTable.getLibPackageIds());
-            if (!libPackageIds.isEmpty()) {
-                List<String> usesLibrary = mApkInfo.getUsesLibrary();
-                libPackageIds.sort(null);
-                for (int id : libPackageIds) {
-                    usesLibrary.add(mTable.getDynamicRefPackageName(id));
-                }
+            libPackageIds.sort(null);
+            for (int id : libPackageIds) {
+                usesLibrary.add(mTable.getDynamicRefPackageName(id));
+            }
+
+            if (isDecodingWithLibraryApks()) {
+                usesLibrary.addAll(mConfig.getLibraryApkFileMap().keySet());
+            }
+
+            if (!usesLibrary.isEmpty()) {
+                List<String> apkUsesLibrary = mApkInfo.getUsesLibrary();
+                apkUsesLibrary.clear();
+                apkUsesLibrary.addAll(usesLibrary);
             }
         } else {
             // Renaming not possible: manifest decoded without resources.

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/ResTable.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/ResTable.java
@@ -98,21 +98,35 @@ public class ResTable {
         }
 
         loadPackagesFromApk(apkFile, zipDir, true);
+        mMainPackage = selectMainPackageGroup().getBasePackage();
+        preloadLibraryApks();
+    }
 
-        ResPackageGroup pkgGroup;
+    private ResPackageGroup selectMainPackageGroup() {
         if (mPackageGroups.isEmpty()) {
             // Empty resources.arsc, create a dummy package group.
-            pkgGroup = new ResPackageGroup(this, 0, "");
+            ResPackageGroup pkgGroup = new ResPackageGroup(this, 0, "");
             mPackageGroups.put(0, pkgGroup);
-        } else if (mPackageGroups.containsKey(APP_PACKAGE_ID)) {
-            // Prefer the standard app package group.
-            pkgGroup = mPackageGroups.get(APP_PACKAGE_ID);
-        } else {
-            // Fall back to the first package group in the table.
-            pkgGroup = mPackageGroups.values().iterator().next();
+            return pkgGroup;
         }
 
-        mMainPackage = pkgGroup.getBasePackage();
+        if (mPackageGroups.containsKey(APP_PACKAGE_ID)) {
+            // Prefer the standard app package group.
+            return mPackageGroups.get(APP_PACKAGE_ID);
+        }
+
+        // Fall back to the first package group in the table.
+        return mPackageGroups.values().iterator().next();
+    }
+
+    private void preloadLibraryApks() throws AndrolibException {
+        if (!mConfig.hasLibraryFiles()) {
+            return;
+        }
+
+        for (File apkFile : mConfig.getUniqueLibraryApkFiles()) {
+            loadPackagesFromApk(apkFile);
+        }
     }
 
     private void loadPackagesFromApk(File apkFile, ZipRODirectory zipDir, boolean isMainPackage)
@@ -197,19 +211,11 @@ public class ResTable {
 
     private ResPackageGroup loadLibraryById(int id) throws AndrolibException {
         String name = mDynamicRefTable.get(id);
-        String[] libFiles = mConfig.getLibraryFiles();
-        if (name == null || libFiles == null) {
+        if (name == null) {
             return null;
         }
 
-        File apkFile = null;
-        for (String libEntry : libFiles) {
-            String[] parts = libEntry.split(":", 2);
-            if (parts.length == 2 && name.equals(parts[0])) {
-                apkFile = new File(parts[1]);
-                break;
-            }
-        }
+        File apkFile = mConfig.getLibraryApkFileMap().get(name);
         if (apkFile == null) {
             return null;
         }

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/PreloadedLibraryDecodeTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/PreloadedLibraryDecodeTest.java
@@ -1,0 +1,116 @@
+/*
+ *  Copyright (C) 2010 Ryszard Wiśniewski <brut.alll@gmail.com>
+ *  Copyright (C) 2010 Connor Tumbleson <connor.tumbleson@gmail.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package brut.androlib;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class PreloadedLibraryDecodeTest extends BaseTest {
+    private static final String LIBRARY_NAME = "com.example.preload";
+
+    @Test
+    public void isExplicitLibraryIncludePreservedInDecodedMeta() throws Exception {
+        File testDir = new File(sTmpDir, "preloaded_library_decode");
+        File libraryDir = new File(testDir, "library");
+        File mainDir = new File(testDir, "main");
+
+        writeFixtureFile(new File(libraryDir, "AndroidManifest.xml"), getManifest("Lib"));
+        writeFixtureFile(new File(libraryDir, "apktool.yml"), getApktoolYml("preload-lib.apk", null));
+        writeFixtureFile(new File(libraryDir, "res/drawable/lib_icon.xml"), getLibraryDrawable());
+
+        writeFixtureFile(new File(mainDir, "AndroidManifest.xml"), getManifest("Main"));
+        writeFixtureFile(new File(mainDir, "apktool.yml"), getApktoolYml("preload-main.apk", LIBRARY_NAME));
+        writeFixtureFile(new File(mainDir, "res/values/drawables.xml"), getMainDrawables());
+
+        File libraryApk = new File(testDir, "preload-lib.apk");
+        new ApkBuilder(libraryDir, sConfig).build(libraryApk);
+
+        sConfig.setLibraryFiles(new String[] {
+            LIBRARY_NAME + ":" + libraryApk.getAbsolutePath()
+        });
+
+        File mainApk = new File(testDir, "preload-main.apk");
+        new ApkBuilder(mainDir, sConfig).build(mainApk);
+
+        File decodedDir = new File(testDir, "decoded");
+        new ApkDecoder(mainApk, sConfig).decode(decodedDir);
+
+        String apktoolYml = readTextFile(new File(decodedDir, "apktool.yml"));
+        assertTrue(apktoolYml.contains("usesLibrary:"));
+        assertTrue(apktoolYml.contains("- " + LIBRARY_NAME));
+    }
+
+    private static void writeFixtureFile(File file, String contents) throws Exception {
+        File parentDir = file.getParentFile();
+        if (parentDir != null) {
+            Files.createDirectories(parentDir.toPath());
+        }
+        Files.write(file.toPath(), contents.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String getManifest(String label) {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+            + "<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\"\n"
+            + "    package=\"" + LIBRARY_NAME + "\"\n"
+            + "    platformBuildVersionCode=\"35\"\n"
+            + "    platformBuildVersionName=\"15\">\n"
+            + "    <application android:label=\"" + label + "\" />\n"
+            + "</manifest>\n";
+    }
+
+    private static String getApktoolYml(String apkFileName, String usesLibrary) {
+        StringBuilder yml = new StringBuilder();
+        yml.append("version: 2.0.0\n");
+        yml.append("apkFileName: ").append(apkFileName).append('\n');
+        yml.append("usesFramework:\n");
+        yml.append("  ids:\n");
+        yml.append("  - 1\n");
+        if (usesLibrary != null) {
+            yml.append("usesLibrary:\n");
+            yml.append("- ").append(usesLibrary).append('\n');
+        }
+        yml.append("sdkInfo:\n");
+        yml.append("  minSdkVersion: 21\n");
+        yml.append("  targetSdkVersion: 35\n");
+        yml.append("resourcesInfo:\n");
+        yml.append("  packageId: 127\n");
+        yml.append("versionInfo:\n");
+        yml.append("  versionCode: 1\n");
+        yml.append("  versionName: 1.0\n");
+        return yml.toString();
+    }
+
+    private static String getLibraryDrawable() {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+            + "<shape xmlns:android=\"http://schemas.android.com/apk/res/android\" android:shape=\"rectangle\">\n"
+            + "    <size android:width=\"24dp\" android:height=\"24dp\" />\n"
+            + "    <solid android:color=\"#ff0000\" />\n"
+            + "</shape>\n";
+    }
+
+    private static String getMainDrawables() {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+            + "<resources>\n"
+            + "    <drawable name=\"alias_icon\">@drawable/lib_icon</drawable>\n"
+            + "</resources>\n";
+    }
+}


### PR DESCRIPTION
**Summary**

Improve shared-library APK handling during decode and rebuild.

This change preloads APKs passed via `--lib` into the resource table during decode so cross-package resource references can be resolved correctly. It also keeps generated output scoped to the main decoded package and preserves library metadata in `apktool.yml` so rebuilds can pass the same includes back to `aapt2`.

**What changed**

- Add centralized helpers in `Config` for parsing and querying `--lib package:path` entries.
- Preload unique library APK files in `ResTable` after loading the main package.
- Reuse the centralized library lookup in `ResTable` and `AaptInvoker`.
- Restrict decoded value/file entry enumeration to the main package when library APKs are preloaded.
- Skip staging XML generation for decode sessions that explicitly preload library APKs.
- Persist explicitly supplied library package names into `usesLibrary` so rebuilds retain the required `-I` inputs.

**Why**

Some apps rely on resource aliases or references whose targets live in APKs supplied via `--lib`. Previously, those references could remain unresolved during decode, which led to incomplete values XML output and rebuild failures or broken runtime resources. This change makes decode/rebuild behavior consistent when external library APKs are intentionally provided.

**Validation**

- Built successfully with `gradlew.bat shadowJar`
- Verified decode output now preserves resolved resource aliases
- Verified decoded `apktool.yml` records `usesLibrary` for rebuild reuse
- Add unit test PreloadedLibraryDecodeTest