### PR TITLE
 Fix apktool decompile crash on split APKs with missing type specs

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkBuilder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkBuilder.java
@@ -68,6 +68,7 @@ public class ApkBuilder {
         }
         try {
             mApkInfo = ApkInfo.load(mApkDir);
+            resolveStoredLibraryFiles();
             String minSdkVersion = mApkInfo.getSdkInfo().getMinSdkVersion();
             mSmaliBuilder = new SmaliBuilder(minSdkVersion != null ? SdkInfo.parseSdkInt(minSdkVersion) : 0);
             mAaptInvoker = new AaptInvoker(mApkInfo, mConfig);
@@ -437,5 +438,35 @@ public class ApkBuilder {
 
     private boolean isFileNewer(File file, File reference) {
         return !reference.exists() || BrutIO.recursiveModifiedTime(file) > BrutIO.recursiveModifiedTime(reference);
+    }
+
+    private void resolveStoredLibraryFiles() {
+        if (mConfig.hasLibraryFiles()) {
+            return;
+        }
+
+        List<String> storedLibraryFiles = mApkInfo.getLibraryFiles();
+        if (storedLibraryFiles.isEmpty()) {
+            return;
+        }
+
+        List<String> resolvedLibraryFiles = new ArrayList<>();
+        for (String libraryFile : storedLibraryFiles) {
+            String[] parts = libraryFile.split(":", 2);
+            if (parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty()) {
+                continue;
+            }
+
+            File apkFile = new File(mApkDir, parts[1]);
+            if (!apkFile.isFile()) {
+                Log.w(TAG, "Stored shared library was not found: " + apkFile);
+                continue;
+            }
+            resolvedLibraryFiles.add(parts[0] + ":" + apkFile.getPath());
+        }
+
+        if (!resolvedLibraryFiles.isEmpty()) {
+            mConfig.setLibraryFiles(resolvedLibraryFiles.toArray(new String[0]));
+        }
     }
 }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
@@ -21,6 +21,7 @@ import brut.androlib.exceptions.InFileNotFoundException;
 import brut.androlib.exceptions.OutDirExistsException;
 import brut.androlib.meta.ApkInfo;
 import brut.androlib.res.ResDecoder;
+import brut.common.BrutException;
 import brut.androlib.smali.SmaliDecoder;
 import brut.common.Log;
 import brut.directory.Directory;
@@ -333,7 +334,38 @@ public class ApkDecoder {
             throw new AndrolibException(ex);
         }
 
+        persistLibraryFiles(outDir);
+
         // Serialize apk info to file.
         mApkInfo.save(outDir);
+    }
+
+    private void persistLibraryFiles(File outDir) throws AndrolibException {
+        List<String> apkLibraryFiles = mApkInfo.getLibraryFiles();
+        apkLibraryFiles.clear();
+
+        Map<String, File> libraryApkFiles = mConfig.getLibraryApkFileMap();
+        if (libraryApkFiles.isEmpty()) {
+            return;
+        }
+
+        File libraryDir = new File(outDir, "original/apktool-libs");
+        OS.mkdir(libraryDir);
+
+        for (Map.Entry<String, File> entry : libraryApkFiles.entrySet()) {
+            String packageName = entry.getKey();
+            File libraryApk = entry.getValue();
+            if (packageName == null || packageName.isEmpty() || libraryApk == null || !libraryApk.isFile()) {
+                continue;
+            }
+
+            File outFile = new File(libraryDir, packageName + ".apk");
+            try {
+                OS.cpfile(libraryApk, outFile);
+            } catch (BrutException ex) {
+                throw new AndrolibException(ex);
+            }
+            apkLibraryFiles.add(packageName + ":original/apktool-libs/" + outFile.getName());
+        }
     }
 }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
@@ -20,7 +20,12 @@ import brut.androlib.exceptions.AndrolibException;
 import brut.androlib.exceptions.InFileNotFoundException;
 import brut.androlib.exceptions.OutDirExistsException;
 import brut.androlib.meta.ApkInfo;
+import brut.androlib.meta.SdkInfo;
 import brut.androlib.res.ResDecoder;
+import brut.androlib.res.decoder.BinaryXmlResourceParser;
+import brut.androlib.res.decoder.ManifestPullEventHandler;
+import brut.androlib.res.decoder.ResXmlPullStreamDecoder;
+import brut.androlib.res.xml.ResXmlSerializer;
 import brut.common.BrutException;
 import brut.androlib.smali.SmaliDecoder;
 import brut.common.Log;
@@ -334,10 +339,69 @@ public class ApkDecoder {
             throw new AndrolibException(ex);
         }
 
+        inheritMissingSdkInfoFromLibraries();
         persistLibraryFiles(outDir);
 
         // Serialize apk info to file.
         mApkInfo.save(outDir);
+    }
+
+    private void inheritMissingSdkInfoFromLibraries() throws AndrolibException {
+        SdkInfo sdkInfo = mApkInfo.getSdkInfo();
+        if (!sdkInfo.isEmpty()) {
+            return;
+        }
+
+        Map<String, File> libraryApkFiles = mConfig.getLibraryApkFileMap();
+        if (libraryApkFiles.isEmpty()) {
+            return;
+        }
+
+        for (File libraryApkFile : libraryApkFiles.values()) {
+            if (libraryApkFile == null || !libraryApkFile.isFile()) {
+                continue;
+            }
+
+            SdkInfo librarySdkInfo = loadSdkInfoFromApk(libraryApkFile);
+            if (!librarySdkInfo.isEmpty()) {
+                sdkInfo.setMinSdkVersion(librarySdkInfo.getMinSdkVersion());
+                sdkInfo.setTargetSdkVersion(librarySdkInfo.getTargetSdkVersion());
+                sdkInfo.setMaxSdkVersion(librarySdkInfo.getMaxSdkVersion());
+                return;
+            }
+        }
+    }
+
+    private SdkInfo loadSdkInfoFromApk(File apkFile) throws AndrolibException {
+        ApkInfo apkInfo = new ApkInfo();
+        apkInfo.setApkFile(new ExtFile(apkFile));
+
+        ResDecoder decoder = new ResDecoder(apkInfo, mConfig);
+        BinaryXmlResourceParser parser = new BinaryXmlResourceParser(
+            decoder.getTable(), mConfig.isIgnoreRawValues(), mConfig.isDecodeResolveLazy());
+        ResXmlSerializer serial = new ResXmlSerializer(true);
+        ManifestPullEventHandler handler = new ManifestPullEventHandler(apkInfo, false);
+        ResXmlPullStreamDecoder streamDecoder = new ResXmlPullStreamDecoder(parser, serial, handler);
+
+        try {
+            decoder.getTable().load();
+            Directory inDir = apkInfo.getApkFile().getDirectory();
+            try (
+                InputStream in = inDir.getFileInput("AndroidManifest.xml");
+                OutputStream out = OutputStream.nullOutputStream()
+            ) {
+                streamDecoder.decode(in, out);
+            }
+        } catch (DirectoryException | IOException ex) {
+            throw new AndrolibException(ex);
+        } finally {
+            try {
+                apkInfo.getApkFile().close();
+            } catch (DirectoryException ignored) {
+            }
+        }
+
+        return apkInfo.getSdkInfo();
     }
 
     private void persistLibraryFiles(File outDir) throws AndrolibException {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/Config.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/Config.java
@@ -16,6 +16,13 @@
  */
 package brut.androlib;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+
 public class Config {
     public enum DecodeSources { FULL, ONLY_MAIN_CLASSES, NONE }
     public enum DecodeResources { FULL, ONLY_MANIFEST, NONE }
@@ -116,6 +123,39 @@ public class Config {
 
     public void setLibraryFiles(String[] libraryFiles) {
         mLibraryFiles = libraryFiles;
+    }
+
+    public boolean hasLibraryFiles() {
+        return mLibraryFiles != null && mLibraryFiles.length > 0;
+    }
+
+    public Map<String, File> getLibraryApkFileMap() {
+        Map<String, File> apkFiles = new LinkedHashMap<>();
+        if (!hasLibraryFiles()) {
+            return apkFiles;
+        }
+
+        for (String libEntry : mLibraryFiles) {
+            String[] parts = libEntry.split(":", 2);
+            if (parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty()) {
+                continue;
+            }
+
+            apkFiles.putIfAbsent(parts[0], new File(parts[1]));
+        }
+        return apkFiles;
+    }
+
+    public Collection<File> getUniqueLibraryApkFiles() {
+        Collection<File> files = new ArrayList<>();
+        LinkedHashSet<String> seenPaths = new LinkedHashSet<>();
+        for (File apkFile : getLibraryApkFileMap().values()) {
+            String apkPath = apkFile.getAbsolutePath();
+            if (seenPaths.add(apkPath)) {
+                files.add(apkFile);
+            }
+        }
+        return files;
     }
 
     public boolean isForced() {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/Config.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/Config.java
@@ -158,6 +158,24 @@ public class Config {
         return files;
     }
 
+    public void setLibraryApkFileMap(Map<String, File> libraryApkFiles) {
+        if (libraryApkFiles == null || libraryApkFiles.isEmpty()) {
+            mLibraryFiles = null;
+            return;
+        }
+
+        Collection<String> libraryFiles = new ArrayList<>();
+        for (Map.Entry<String, File> entry : libraryApkFiles.entrySet()) {
+            String packageName = entry.getKey();
+            File apkFile = entry.getValue();
+            if (packageName == null || packageName.isEmpty() || apkFile == null) {
+                continue;
+            }
+            libraryFiles.add(packageName + ":" + apkFile.getPath());
+        }
+        mLibraryFiles = libraryFiles.toArray(new String[0]);
+    }
+
     public boolean isForced() {
         return mForced;
     }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/meta/ApkInfo.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/meta/ApkInfo.java
@@ -48,6 +48,7 @@ public class ApkInfo implements YamlSerializable {
     private String mApkFileName;
     private final UsesFramework mUsesFramework;
     private final List<String> mUsesLibrary;
+    private final List<String> mLibraryFiles;
     private final SdkInfo mSdkInfo;
     private final VersionInfo mVersionInfo;
     private final ResourcesInfo mResourcesInfo;
@@ -62,6 +63,7 @@ public class ApkInfo implements YamlSerializable {
         mApkFileName = null;
         mUsesFramework = new UsesFramework();
         mUsesLibrary = new ArrayList<>();
+        mLibraryFiles = new ArrayList<>();
         mSdkInfo = new SdkInfo();
         mVersionInfo = new VersionInfo();
         mResourcesInfo = new ResourcesInfo();
@@ -113,6 +115,10 @@ public class ApkInfo implements YamlSerializable {
                 mUsesLibrary.clear();
                 reader.readStringList(mUsesLibrary);
                 break;
+            case "libraryFiles":
+                mLibraryFiles.clear();
+                reader.readStringList(mLibraryFiles);
+                break;
             case "sdkInfo":
                 mSdkInfo.clear();
                 reader.readObject(mSdkInfo);
@@ -145,6 +151,9 @@ public class ApkInfo implements YamlSerializable {
         }
         if (!mUsesLibrary.isEmpty()) {
             writer.writeList("usesLibrary", mUsesLibrary);
+        }
+        if (!mLibraryFiles.isEmpty()) {
+            writer.writeList("libraryFiles", mLibraryFiles);
         }
         if (!mSdkInfo.isEmpty()) {
             writer.writeObject("sdkInfo", mSdkInfo);
@@ -185,6 +194,10 @@ public class ApkInfo implements YamlSerializable {
 
     public List<String> getUsesLibrary() {
         return mUsesLibrary;
+    }
+
+    public List<String> getLibraryFiles() {
+        return mLibraryFiles;
     }
 
     public SdkInfo getSdkInfo() {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AaptInvoker.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AaptInvoker.java
@@ -23,11 +23,21 @@ import brut.androlib.res.Framework;
 import brut.common.BrutException;
 import brut.common.Log;
 import brut.util.OS;
+import brut.xml.XmlUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import javax.xml.parsers.ParserConfigurationException;
 
 public class AaptInvoker {
     private static final String TAG = AaptInvoker.class.getName();
@@ -57,6 +67,7 @@ public class AaptInvoker {
 
         List<String> cmd = new ArrayList<>();
         File resZip = null;
+        File stableIdsFile = null;
 
         if (resDir != null) {
             resZip = new File(resDir.getParent(), "build/resources.zip");
@@ -96,6 +107,8 @@ public class AaptInvoker {
         if (manifest == null) {
             return;
         }
+
+        stableIdsFile = createStableIdsFile(resDir);
 
         // Link resources to the final apk.
         cmd.add(aaptPath);
@@ -174,6 +187,10 @@ public class AaptInvoker {
         if (mConfig.isVerbose()) {
             cmd.add("-v");
         }
+        if (stableIdsFile != null) {
+            cmd.add("--stable-ids");
+            cmd.add(stableIdsFile.getPath());
+        }
         if (resZip != null) {
             cmd.add(resZip.getPath());
         }
@@ -183,6 +200,8 @@ public class AaptInvoker {
             Log.d(TAG, "aapt2 link command ran: " + cmd.toString());
         } catch (BrutException ex) {
             throw new AndrolibException(ex);
+        } finally {
+            deleteTempFile(stableIdsFile);
         }
     }
 
@@ -213,5 +232,68 @@ public class AaptInvoker {
         }
 
         return files;
+    }
+
+    private File createStableIdsFile(File resDir) throws AndrolibException {
+        if (resDir == null) {
+            return null;
+        }
+
+        String packageName = mApkInfo.getResourcesInfo().getPackageName();
+        if (packageName == null || packageName.isEmpty()) {
+            return null;
+        }
+
+        File publicXml = new File(resDir, "values/public.xml");
+        if (!publicXml.isFile()) {
+            return null;
+        }
+
+        try {
+            Document doc = XmlUtils.loadDocument(publicXml);
+            NodeList children = doc.getDocumentElement().getChildNodes();
+            List<String> stableIds = new ArrayList<>();
+            for (int i = 0; i < children.getLength(); i++) {
+                Node child = children.item(i);
+                if (child.getNodeType() != Node.ELEMENT_NODE) {
+                    continue;
+                }
+
+                Element element = (Element) child;
+                if (!element.getTagName().equals("public")) {
+                    continue;
+                }
+
+                String type = element.getAttribute("type");
+                String name = element.getAttribute("name");
+                String id = element.getAttribute("id");
+                if (type.isEmpty() || name.isEmpty() || id.isEmpty()) {
+                    continue;
+                }
+                stableIds.add(packageName + ":" + type + "/" + name + " = " + id);
+            }
+
+            if (stableIds.isEmpty()) {
+                return null;
+            }
+
+            File stableIdsFile = File.createTempFile("APKTOOL", ".ids");
+            Files.write(stableIdsFile.toPath(), stableIds, StandardCharsets.UTF_8);
+            return stableIdsFile;
+        } catch (IOException | SAXException | ParserConfigurationException ex) {
+            throw new AndrolibException(ex);
+        }
+    }
+
+    private void deleteTempFile(File file) {
+        if (file == null) {
+            return;
+        }
+
+        try {
+            Files.deleteIfExists(file.toPath());
+        } catch (IOException ex) {
+            Log.w(TAG, "Could not delete temp stable-ids file: %s", ex.getMessage());
+        }
     }
 }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AaptInvoker.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AaptInvoker.java
@@ -201,18 +201,9 @@ public class AaptInvoker {
 
         List<String> usesLibrary = mApkInfo.getUsesLibrary();
         if (!usesLibrary.isEmpty()) {
-            String[] libFiles = mConfig.getLibraryFiles();
+            Map<String, File> libraryApkFiles = mConfig.getLibraryApkFileMap();
             for (String name : usesLibrary) {
-                File libFile = null;
-                if (libFiles != null) {
-                    for (String libEntry : libFiles) {
-                        String[] parts = libEntry.split(":", 2);
-                        if (parts.length == 2 && name.equals(parts[0])) {
-                            libFile = new File(parts[1]);
-                            break;
-                        }
-                    }
-                }
+                File libFile = libraryApkFiles.get(name);
                 if (libFile != null) {
                     files.add(libFile);
                 } else {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/ResDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/ResDecoder.java
@@ -92,14 +92,14 @@ public class ResDecoder {
         ResPackage pkg = mTable.getMainPackage();
 
         Log.i(TAG, "Decoding value resources...");
-        for (ResEntry entry : Lists.newArrayList(pkg.getGroup().listEntries())) {
+        for (ResEntry entry : Lists.newArrayList(getDecodeEntries(pkg))) {
             if (entry.getValue() instanceof ResBag) {
                 ((ResBag) entry.getValue()).resolveKeys();
             }
         }
 
         Log.i(TAG, "Decoding file resources...");
-        for (ResEntry entry : Lists.newArrayList(pkg.getGroup().listEntries())) {
+        for (ResEntry entry : Lists.newArrayList(getDecodeEntries(pkg))) {
             if (entry.getValue() instanceof ResFileReference) {
                 fileDecoder.decode(entry, inDir, outDir, mResFileMap);
             }
@@ -122,9 +122,10 @@ public class ResDecoder {
 
     private void generateValuesXmls(ResPackage pkg, Directory outDir, ResXmlSerializer serial)
             throws AndrolibException {
-        // Group entries by type name + qualifiers, ignoring alias duplicates in sub-packages.
+        // Group entries by type name + qualifiers. When library APKs are preloaded for reference
+        // resolution, keep the generated values scoped to the main decoded package only.
         Map<Pair<String, String>, List<ResEntry>> entriesMap = new HashMap<>();
-        for (ResEntry entry : pkg.getGroup().listEntries()) {
+        for (ResEntry entry : getDecodeEntries(pkg)) {
             if (entry.getValue() instanceof ValuesXmlSerializable && !pkg.isAlias(entry.getResId())) {
                 ResType type = entry.getType();
                 Pair<String, String> key = Pair.of(type.getName(), type.getConfig().toQualifiers());
@@ -189,7 +190,7 @@ public class ResDecoder {
 
     private void generateStagingXmls(ResPackage pkg, Directory outDir, ResXmlSerializer serial)
             throws AndrolibException {
-        if (pkg.getGroup().getPackageCount() <= 1) {
+        if (pkg.getGroup().getPackageCount() <= 1 || isDecodingWithLibraryApks()) {
             return;
         }
 
@@ -299,6 +300,14 @@ public class ResDecoder {
                 throw new AndrolibException("Could not generate: " + outFileName, ex);
             }
         }
+    }
+
+    private Iterable<ResEntry> getDecodeEntries(ResPackage pkg) {
+        return isDecodingWithLibraryApks() ? pkg.listEntries() : pkg.getGroup().listEntries();
+    }
+
+    private boolean isDecodingWithLibraryApks() {
+        return mConfig.hasLibraryFiles();
     }
 
     private void generateOverlayableXml(ResPackage pkg, Directory outDir, ResXmlSerializer serial)
@@ -431,14 +440,25 @@ public class ResDecoder {
                 usesFramework.setTag(mConfig.getFrameworkTag());
             }
 
-            // Record library package names used by the resource table.
+            // Record library package names used by the resource table. If library APKs were
+            // preloaded explicitly for decode-time reference resolution, preserve those names so
+            // the same includes can be passed back to aapt2 during rebuild.
+            LinkedHashSet<String> usesLibrary = new LinkedHashSet<>(mApkInfo.getUsesLibrary());
+
             List<Integer> libPackageIds = Lists.newArrayList(mTable.getLibPackageIds());
-            if (!libPackageIds.isEmpty()) {
-                List<String> usesLibrary = mApkInfo.getUsesLibrary();
-                libPackageIds.sort(null);
-                for (int id : libPackageIds) {
-                    usesLibrary.add(mTable.getDynamicRefPackageName(id));
-                }
+            libPackageIds.sort(null);
+            for (int id : libPackageIds) {
+                usesLibrary.add(mTable.getDynamicRefPackageName(id));
+            }
+
+            if (isDecodingWithLibraryApks()) {
+                usesLibrary.addAll(mConfig.getLibraryApkFileMap().keySet());
+            }
+
+            if (!usesLibrary.isEmpty()) {
+                List<String> apkUsesLibrary = mApkInfo.getUsesLibrary();
+                apkUsesLibrary.clear();
+                apkUsesLibrary.addAll(usesLibrary);
             }
         } else {
             // Renaming not possible: manifest decoded without resources.

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/ResDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/ResDecoder.java
@@ -509,23 +509,7 @@ public class ResDecoder {
                 usesFramework.setTag(mConfig.getFrameworkTag());
             }
 
-            // Record library package names used by the resource table. If library APKs were
-            LinkedHashSet<String> usesLibrary = new LinkedHashSet<>(mApkInfo.getUsesLibrary());
-
-            List<Integer> libPackageIds = Lists.newArrayList(mTable.getLibPackageIds());
-            libPackageIds.sort(null);
-            for (int id : libPackageIds) {
-                String packageName = mTable.getDynamicRefPackageName(id);
-                if (packageName != null && !packageName.equals(pkg.getName())) {
-                    usesLibrary.add(packageName);
-                }
-            }
-
-            if (isDecodingWithLibraryApks()) {
-                for (String packageName : mConfig.getLibraryApkFileMap().keySet()) {
-                    usesLibrary.add(packageName);
-                }
-            }
+            LinkedHashSet<String> usesLibrary = collectUsesLibrary(pkg);
 
             if (!usesLibrary.isEmpty()) {
                 List<String> apkUsesLibrary = mApkInfo.getUsesLibrary();
@@ -559,5 +543,24 @@ public class ResDecoder {
                 featureFlags.put(flag, value);
             }
         }
+    }
+
+    private LinkedHashSet<String> collectUsesLibrary(ResPackage pkg) {
+        LinkedHashSet<String> usesLibrary = new LinkedHashSet<>(mApkInfo.getUsesLibrary());
+        String mainPackageName = pkg.getName();
+
+        List<Integer> libPackageIds = Lists.newArrayList(mTable.getLibPackageIds());
+        libPackageIds.sort(null);
+        for (int id : libPackageIds) {
+            String packageName = mTable.getDynamicRefPackageName(id);
+            if (packageName != null && !packageName.equals(mainPackageName)) {
+                usesLibrary.add(packageName);
+            }
+        }
+
+        if (isDecodingWithLibraryApks()) {
+            usesLibrary.addAll(mConfig.getLibraryApkFileMap().keySet());
+        }
+        return usesLibrary;
     }
 }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/ResDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/ResDecoder.java
@@ -510,8 +510,6 @@ public class ResDecoder {
             }
 
             // Record library package names used by the resource table. If library APKs were
-            // preloaded explicitly for decode-time reference resolution, preserve those names so
-            // the same includes can be passed back to aapt2 during rebuild.
             LinkedHashSet<String> usesLibrary = new LinkedHashSet<>(mApkInfo.getUsesLibrary());
 
             List<Integer> libPackageIds = Lists.newArrayList(mTable.getLibPackageIds());
@@ -525,9 +523,7 @@ public class ResDecoder {
 
             if (isDecodingWithLibraryApks()) {
                 for (String packageName : mConfig.getLibraryApkFileMap().keySet()) {
-                    if (!packageName.equals(pkg.getName())) {
-                        usesLibrary.add(packageName);
-                    }
+                    usesLibrary.add(packageName);
                 }
             }
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/ResDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/ResDecoder.java
@@ -34,6 +34,7 @@ import brut.common.Log;
 import brut.directory.Directory;
 import brut.directory.DirectoryException;
 import brut.directory.FileDirectory;
+import brut.directory.ZipRODirectory;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -99,9 +100,21 @@ public class ResDecoder {
         }
 
         Log.i(TAG, "Decoding file resources...");
-        for (ResEntry entry : Lists.newArrayList(getDecodeEntries(pkg))) {
-            if (entry.getValue() instanceof ResFileReference) {
-                fileDecoder.decode(entry, inDir, outDir, mResFileMap);
+        Map<File, ZipRODirectory> splitInDirs = new HashMap<>();
+        try {
+            for (ResEntry entry : Lists.newArrayList(getDecodeEntries(pkg))) {
+                if (entry.getValue() instanceof ResFileReference) {
+                    Directory entryInDir = getInputDirectory(entry, inDir, splitInDirs);
+                    fileDecoder.decode(entry, entryInDir, outDir, mResFileMap);
+                }
+            }
+        } finally {
+            for (ZipRODirectory splitInDir : splitInDirs.values()) {
+                try {
+                    splitInDir.close();
+                } catch (DirectoryException ex) {
+                    Log.w(TAG, "Could not close split resource directory: %s", ex.getMessage());
+                }
             }
         }
 
@@ -122,8 +135,9 @@ public class ResDecoder {
 
     private void generateValuesXmls(ResPackage pkg, Directory outDir, ResXmlSerializer serial)
             throws AndrolibException {
-        // Group entries by type name + qualifiers. When library APKs are preloaded for reference
-        // resolution, keep the generated values scoped to the main decoded package only.
+        // Group entries by type name + qualifiers. When same-package split APKs are preloaded for
+        // reference resolution, keep their real resources in the decoded output while filtering out
+        // parser-created dummy placeholders.
         Map<Pair<String, String>, List<ResEntry>> entriesMap = new HashMap<>();
         for (ResEntry entry : getDecodeEntries(pkg)) {
             if (entry.getValue() instanceof ValuesXmlSerializable && !pkg.isAlias(entry.getResId())) {
@@ -164,7 +178,7 @@ public class ResDecoder {
 
     private void generatePublicXml(ResPackage pkg, Directory outDir, ResXmlSerializer serial)
             throws AndrolibException {
-        List<ResEntrySpec> specs = Lists.newArrayList(pkg.listEntrySpecs());
+        List<ResEntrySpec> specs = Lists.newArrayList(getDecodeEntrySpecs(pkg));
         specs.sort(Comparator.comparing(ResEntrySpec::getResId));
 
         String outFileName = "res/values/public.xml";
@@ -303,7 +317,62 @@ public class ResDecoder {
     }
 
     private Iterable<ResEntry> getDecodeEntries(ResPackage pkg) {
-        return isDecodingWithLibraryApks() ? pkg.listEntries() : pkg.getGroup().listEntries();
+        if (!isDecodingWithLibraryApks()) {
+            return pkg.getGroup().listEntries();
+        }
+
+        List<ResEntry> entries = new ArrayList<>();
+        for (ResEntry entry : pkg.getGroup().listEntries()) {
+            if (shouldDecodeEntry(entry)) {
+                entries.add(entry);
+            }
+        }
+        return entries;
+    }
+
+    private Iterable<ResEntrySpec> getDecodeEntrySpecs(ResPackage pkg) {
+        if (!isDecodingWithLibraryApks()) {
+            return pkg.getGroup().listEntrySpecs();
+        }
+
+        List<ResEntrySpec> specs = new ArrayList<>();
+        Set<ResId> seenSpecs = new HashSet<>();
+        for (ResEntrySpec spec : pkg.getGroup().listEntrySpecs()) {
+            if (shouldDecodeEntrySpec(spec) && seenSpecs.add(spec.getResId())) {
+                specs.add(spec);
+            }
+        }
+        return specs;
+    }
+
+    private boolean shouldDecodeEntry(ResEntry entry) {
+        return shouldDecodeEntrySpec(entry.getSpec());
+    }
+
+    private boolean shouldDecodeEntrySpec(ResEntrySpec spec) {
+        return !spec.getName().startsWith(ResEntrySpec.DUMMY_PREFIX)
+            || spec.getPackage().isSyntheticEntrySpec(spec);
+    }
+
+    private Directory getInputDirectory(ResEntry entry, Directory mainInDir, Map<File, ZipRODirectory> splitInDirs)
+            throws AndrolibException {
+        File sourceApkFile = entry.getPackage().getSourceApkFile();
+        if (sourceApkFile == null || sourceApkFile.equals(mApkInfo.getApkFile())) {
+            return mainInDir;
+        }
+
+        ZipRODirectory splitInDir = splitInDirs.get(sourceApkFile);
+        if (splitInDir != null) {
+            return splitInDir;
+        }
+
+        try {
+            splitInDir = new ZipRODirectory(sourceApkFile);
+        } catch (DirectoryException ex) {
+            throw new AndrolibException("Could not open split resource file: " + sourceApkFile, ex);
+        }
+        splitInDirs.put(sourceApkFile, splitInDir);
+        return splitInDir;
     }
 
     private boolean isDecodingWithLibraryApks() {
@@ -448,11 +517,18 @@ public class ResDecoder {
             List<Integer> libPackageIds = Lists.newArrayList(mTable.getLibPackageIds());
             libPackageIds.sort(null);
             for (int id : libPackageIds) {
-                usesLibrary.add(mTable.getDynamicRefPackageName(id));
+                String packageName = mTable.getDynamicRefPackageName(id);
+                if (packageName != null && !packageName.equals(pkg.getName())) {
+                    usesLibrary.add(packageName);
+                }
             }
 
             if (isDecodingWithLibraryApks()) {
-                usesLibrary.addAll(mConfig.getLibraryApkFileMap().keySet());
+                for (String packageName : mConfig.getLibraryApkFileMap().keySet()) {
+                    if (!packageName.equals(pkg.getName())) {
+                        usesLibrary.add(packageName);
+                    }
+                }
             }
 
             if (!usesLibrary.isEmpty()) {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/BinaryResourceParser.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/BinaryResourceParser.java
@@ -28,6 +28,7 @@ import com.google.common.io.BaseEncoding;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.io.BufferedInputStream;
+import java.io.File;
 import java.io.InputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -81,6 +82,7 @@ public class BinaryResourceParser {
     private final ResTable mTable;
     private final boolean mKeepBrokenResources;
     private final boolean mAllowDummyEntrySpecs;
+    private final File mSourceApkFile;
     private final Set<ResId> mMissingEntrySpecs;
     private final Set<ResConfig> mInvalidConfigs;
 
@@ -96,9 +98,15 @@ public class BinaryResourceParser {
     private List<Pair<Long, Integer>> mEntrySpecFlagsOffsets;
 
     public BinaryResourceParser(ResTable table, boolean keepBrokenResources, boolean allowDummyEntrySpecs) {
+        this(table, keepBrokenResources, allowDummyEntrySpecs, null);
+    }
+
+    public BinaryResourceParser(ResTable table, boolean keepBrokenResources, boolean allowDummyEntrySpecs,
+            File sourceApkFile) {
         mTable = table;
         mKeepBrokenResources = keepBrokenResources;
         mAllowDummyEntrySpecs = allowDummyEntrySpecs;
+        mSourceApkFile = sourceApkFile;
         mMissingEntrySpecs = new HashSet<>();
         mInvalidConfigs = new HashSet<>();
     }
@@ -261,6 +269,7 @@ public class BinaryResourceParser {
         } finally {
             mPackageCount++;
         }
+        mPackage.setSourceApkFile(mSourceApkFile);
 
         parser = new ResChunkPullParser(mIn, parser.dataSize());
         while (nextChunk(parser)) {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/ResPackage.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/ResPackage.java
@@ -21,6 +21,7 @@ import brut.androlib.exceptions.UndefinedResObjectException;
 import brut.androlib.res.table.value.ResValue;
 import org.apache.commons.lang3.tuple.Pair;
 
+import java.io.File;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -38,6 +39,9 @@ public class ResPackage {
     private final Map<String, ResOverlayable> mOverlayables;
     private final Map<ResId, ResId> mAliases;
     private final Set<String> mNameRegistry;
+    private final Set<Pair<ResId, ResConfig>> mSyntheticEntries;
+    private final Set<ResId> mSyntheticSpecs;
+    private File mSourceApkFile;
 
     public ResPackage(ResPackageGroup group, int index) {
         assert group != null && index >= 0;
@@ -50,6 +54,8 @@ public class ResPackage {
         mOverlayables = new HashMap<>();
         mAliases = new HashMap<>();
         mNameRegistry = new HashSet<>();
+        mSyntheticEntries = new HashSet<>();
+        mSyntheticSpecs = new HashSet<>();
     }
 
     public ResTable getTable() {
@@ -70,6 +76,14 @@ public class ResPackage {
 
     public int getIndex() {
         return mIndex;
+    }
+
+    public File getSourceApkFile() {
+        return mSourceApkFile;
+    }
+
+    public void setSourceApkFile(File sourceApkFile) {
+        mSourceApkFile = sourceApkFile;
     }
 
     public boolean hasTypeSpec(int typeId) {
@@ -256,6 +270,21 @@ public class ResPackage {
         return addEntry(typeId, entryId, ResConfig.DEFAULT, value);
     }
 
+    public ResEntry addSyntheticEntry(int typeId, int entryId, String name, ResValue value) throws AndrolibException {
+        if (!hasEntrySpec(typeId, entryId)) {
+            addEntrySpec(typeId, entryId, name);
+        }
+
+        if (!hasEntry(typeId, entryId)) {
+            addEntry(typeId, entryId, value);
+        }
+
+        ResEntry entry = getEntry(typeId, entryId);
+        mSyntheticEntries.add(Pair.of(entry.getResId(), entry.getType().getConfig()));
+        mSyntheticSpecs.add(entry.getResId());
+        return entry;
+    }
+
     public ResEntry addEntry(int typeId, int entryId, ResConfig config, ResValue value) throws AndrolibException {
         ResId resId = ResId.of(getId(), typeId, entryId);
         if (mAliases.containsKey(resId)) {
@@ -293,6 +322,10 @@ public class ResPackage {
 
     public Collection<ResEntry> listEntries() {
         return mEntries.values();
+    }
+
+    public boolean isSyntheticEntrySpec(ResEntrySpec spec) {
+        return mSyntheticSpecs.contains(spec.getResId());
     }
 
     public boolean hasOverlayable(String name) {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/ResPackage.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/ResPackage.java
@@ -39,7 +39,6 @@ public class ResPackage {
     private final Map<String, ResOverlayable> mOverlayables;
     private final Map<ResId, ResId> mAliases;
     private final Set<String> mNameRegistry;
-    private final Set<Pair<ResId, ResConfig>> mSyntheticEntries;
     private final Set<ResId> mSyntheticSpecs;
     private File mSourceApkFile;
 
@@ -54,7 +53,6 @@ public class ResPackage {
         mOverlayables = new HashMap<>();
         mAliases = new HashMap<>();
         mNameRegistry = new HashSet<>();
-        mSyntheticEntries = new HashSet<>();
         mSyntheticSpecs = new HashSet<>();
     }
 
@@ -280,7 +278,6 @@ public class ResPackage {
         }
 
         ResEntry entry = getEntry(typeId, entryId);
-        mSyntheticEntries.add(Pair.of(entry.getResId(), entry.getType().getConfig()));
         mSyntheticSpecs.add(entry.getResId());
         return entry;
     }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/ResTable.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/ResTable.java
@@ -121,11 +121,74 @@ public class ResTable {
 
     private void preloadLibraryApks() throws AndrolibException {
         if (!mConfig.hasLibraryFiles()) {
+            discoverSiblingLibraryApk();
+            if (!mConfig.hasLibraryFiles()) {
+                return;
+            }
+        }
+
+        File mainApkFile = mApkInfo.getApkFile();
+        for (File apkFile : mConfig.getUniqueLibraryApkFiles()) {
+            if (mainApkFile != null && mainApkFile.getAbsoluteFile().equals(apkFile.getAbsoluteFile())) {
+                continue;
+            }
+            loadPackagesFromApk(apkFile);
+        }
+    }
+
+    private void discoverSiblingLibraryApk() throws AndrolibException {
+        File mainApkFile = mApkInfo.getApkFile();
+        if (mainApkFile == null || mainApkFile.getParentFile() == null || mApkInfo.hasSources()) {
+            return;
+        }
+        if (!mainApkFile.getName().toLowerCase().startsWith("config.")) {
             return;
         }
 
-        for (File apkFile : mConfig.getUniqueLibraryApkFiles()) {
-            loadPackagesFromApk(apkFile);
+        String packageName = mMainPackage != null ? mMainPackage.getName() : null;
+        if (packageName == null || packageName.isEmpty()) {
+            return;
+        }
+
+        File libraryApk = findSiblingLibraryApk(mainApkFile);
+        if (libraryApk == null) {
+            return;
+        }
+
+        Map<String, File> libraryApkFiles = new LinkedHashMap<>();
+        libraryApkFiles.put(packageName, libraryApk);
+        mConfig.setLibraryApkFileMap(libraryApkFiles);
+    }
+
+    private File findSiblingLibraryApk(File mainApkFile) {
+        File parentDir = mainApkFile.getParentFile();
+        File[] apkFiles = parentDir.listFiles((dir, name) -> name.endsWith(".apk"));
+        if (apkFiles == null) {
+            return null;
+        }
+
+        File fallbackApk = null;
+        for (File apkFile : apkFiles) {
+            if (mainApkFile.getAbsoluteFile().equals(apkFile.getAbsoluteFile()) || !apkContainsFile(apkFile, "resources.arsc")) {
+                continue;
+            }
+
+            if (apkContainsFile(apkFile, "classes.dex")) {
+                return apkFile;
+            }
+
+            if (fallbackApk == null) {
+                fallbackApk = apkFile;
+            }
+        }
+        return fallbackApk;
+    }
+
+    private boolean apkContainsFile(File apkFile, String fileName) {
+        try (ZipRODirectory zipDir = new ZipRODirectory(apkFile)) {
+            return zipDir.containsFile(fileName);
+        } catch (DirectoryException ignored) {
+            return false;
         }
     }
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/ResTable.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/ResTable.java
@@ -138,8 +138,9 @@ public class ResTable {
 
             try (InputStream in = zipDir.getFileInput("resources.arsc")) {
                 BinaryResourceParser parser = isMainPackage
-                    ? new BinaryResourceParser(this, mConfig.isKeepBrokenResources(), mConfig.isDecodeResolveGreedy())
-                    : new BinaryResourceParser(this, true, true);
+                    ? new BinaryResourceParser(
+                        this, mConfig.isKeepBrokenResources(), mConfig.isDecodeResolveGreedy(), apkFile)
+                    : new BinaryResourceParser(this, true, true, apkFile);
                 parser.parse(in);
 
                 // Only flag the app for the main package.

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/ResTable.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/ResTable.java
@@ -98,21 +98,35 @@ public class ResTable {
         }
 
         loadPackagesFromApk(apkFile, zipDir, true);
+        mMainPackage = selectMainPackageGroup().getBasePackage();
+        preloadLibraryApks();
+    }
 
-        ResPackageGroup pkgGroup;
+    private ResPackageGroup selectMainPackageGroup() {
         if (mPackageGroups.isEmpty()) {
             // Empty resources.arsc, create a dummy package group.
-            pkgGroup = new ResPackageGroup(this, 0, "");
+            ResPackageGroup pkgGroup = new ResPackageGroup(this, 0, "");
             mPackageGroups.put(0, pkgGroup);
-        } else if (mPackageGroups.containsKey(APP_PACKAGE_ID)) {
-            // Prefer the standard app package group.
-            pkgGroup = mPackageGroups.get(APP_PACKAGE_ID);
-        } else {
-            // Fall back to the first package group in the table.
-            pkgGroup = mPackageGroups.values().iterator().next();
+            return pkgGroup;
         }
 
-        mMainPackage = pkgGroup.getBasePackage();
+        if (mPackageGroups.containsKey(APP_PACKAGE_ID)) {
+            // Prefer the standard app package group.
+            return mPackageGroups.get(APP_PACKAGE_ID);
+        }
+
+        // Fall back to the first package group in the table.
+        return mPackageGroups.values().iterator().next();
+    }
+
+    private void preloadLibraryApks() throws AndrolibException {
+        if (!mConfig.hasLibraryFiles()) {
+            return;
+        }
+
+        for (File apkFile : mConfig.getUniqueLibraryApkFiles()) {
+            loadPackagesFromApk(apkFile);
+        }
     }
 
     private void loadPackagesFromApk(File apkFile, ZipRODirectory zipDir, boolean isMainPackage)
@@ -197,19 +211,11 @@ public class ResTable {
 
     private ResPackageGroup loadLibraryById(int id) throws AndrolibException {
         String name = mDynamicRefTable.get(id);
-        String[] libFiles = mConfig.getLibraryFiles();
-        if (name == null || libFiles == null) {
+        if (name == null) {
             return null;
         }
 
-        File apkFile = null;
-        for (String libEntry : libFiles) {
-            String[] parts = libEntry.split(":", 2);
-            if (parts.length == 2 && name.equals(parts[0])) {
-                apkFile = new File(parts[1]);
-                break;
-            }
-        }
+        File apkFile = mConfig.getLibraryApkFileMap().get(name);
         if (apkFile == null) {
             return null;
         }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResEnum.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResEnum.java
@@ -62,8 +62,7 @@ public class ResEnum extends ResAttribute {
                 continue;
             }
 
-            pkg.addEntrySpec(keyId.typeId(), keyId.entryId(), ResEntrySpec.DUMMY_PREFIX + keyId);
-            pkg.addEntry(keyId.typeId(), keyId.entryId(), ResCustom.ID);
+            pkg.addSyntheticEntry(keyId.typeId(), keyId.entryId(), ResEntrySpec.DUMMY_PREFIX + keyId, ResCustom.ID);
         }
     }
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResFlags.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResFlags.java
@@ -64,8 +64,7 @@ public class ResFlags extends ResAttribute {
                 continue;
             }
 
-            pkg.addEntrySpec(keyId.typeId(), keyId.entryId(), ResEntrySpec.DUMMY_PREFIX + keyId);
-            pkg.addEntry(keyId.typeId(), keyId.entryId(), ResCustom.ID);
+            pkg.addSyntheticEntry(keyId.typeId(), keyId.entryId(), ResEntrySpec.DUMMY_PREFIX + keyId, ResCustom.ID);
         }
     }
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResStyle.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResStyle.java
@@ -21,6 +21,7 @@ import brut.androlib.res.table.ResEntry;
 import brut.androlib.res.table.ResEntrySpec;
 import brut.androlib.res.table.ResId;
 import brut.androlib.res.table.ResPackage;
+import brut.androlib.res.table.ResTypeSpec;
 import brut.common.Log;
 import org.xmlpull.v1.XmlSerializer;
 
@@ -96,8 +97,21 @@ public class ResStyle extends ResBag {
                 continue;
             }
 
-            pkg.addEntrySpec(keyId.typeId(), keyId.entryId(), ResEntrySpec.DUMMY_PREFIX + keyId);
-            pkg.addEntry(keyId.typeId(), keyId.entryId(), ResAttribute.DEFAULT);
+            // Some split APKs reference types not present in their partial resources table.
+            // Ensure we don't abort decoding when we can't inject a dummy spec.
+            ResTypeSpec keyType = null;
+            try {
+                keyType = pkg.getGroup().getTypeSpec(keyId.typeId());
+            } catch (AndrolibException ex) {
+                Log.w(TAG, "Unresolved style reference (missing type spec): key=%s, value=%s", key, item.getValue());
+            }
+            if (keyType == null) {
+                continue;
+            }
+
+            ResPackage keyPkg = keyType.getPackage();
+            keyPkg.addSyntheticEntry(
+                keyId.typeId(), keyId.entryId(), ResEntrySpec.DUMMY_PREFIX + keyId, ResAttribute.DEFAULT);
         }
     }
 

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/PreloadedLibraryDecodeTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/PreloadedLibraryDecodeTest.java
@@ -1,0 +1,116 @@
+/*
+ *  Copyright (C) 2010 Ryszard Wiśniewski <brut.alll@gmail.com>
+ *  Copyright (C) 2010 Connor Tumbleson <connor.tumbleson@gmail.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package brut.androlib;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class PreloadedLibraryDecodeTest extends BaseTest {
+    private static final String LIBRARY_NAME = "com.example.preload";
+
+    @Test
+    public void isExplicitLibraryIncludePreservedInDecodedMeta() throws Exception {
+        File testDir = new File(sTmpDir, "preloaded_library_decode");
+        File libraryDir = new File(testDir, "library");
+        File mainDir = new File(testDir, "main");
+
+        writeFixtureFile(new File(libraryDir, "AndroidManifest.xml"), getManifest("Lib"));
+        writeFixtureFile(new File(libraryDir, "apktool.yml"), getApktoolYml("preload-lib.apk", null));
+        writeFixtureFile(new File(libraryDir, "res/drawable/lib_icon.xml"), getLibraryDrawable());
+
+        writeFixtureFile(new File(mainDir, "AndroidManifest.xml"), getManifest("Main"));
+        writeFixtureFile(new File(mainDir, "apktool.yml"), getApktoolYml("preload-main.apk", LIBRARY_NAME));
+        writeFixtureFile(new File(mainDir, "res/values/drawables.xml"), getMainDrawables());
+
+        File libraryApk = new File(testDir, "preload-lib.apk");
+        new ApkBuilder(libraryDir, sConfig).build(libraryApk);
+
+        sConfig.setLibraryFiles(new String[] {
+            LIBRARY_NAME + ":" + libraryApk.getAbsolutePath()
+        });
+
+        File mainApk = new File(testDir, "preload-main.apk");
+        new ApkBuilder(mainDir, sConfig).build(mainApk);
+
+        File decodedDir = new File(testDir, "decoded");
+        new ApkDecoder(mainApk, sConfig).decode(decodedDir);
+
+        String apktoolYml = readTextFile(new File(decodedDir, "apktool.yml"));
+        assertTrue(apktoolYml.contains("usesLibrary:"));
+        assertTrue(apktoolYml.contains("- " + LIBRARY_NAME));
+    }
+
+    private static void writeFixtureFile(File file, String contents) throws Exception {
+        File parentDir = file.getParentFile();
+        if (parentDir != null) {
+            Files.createDirectories(parentDir.toPath());
+        }
+        Files.write(file.toPath(), contents.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String getManifest(String label) {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+            + "<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\"\n"
+            + "    package=\"" + LIBRARY_NAME + "\"\n"
+            + "    platformBuildVersionCode=\"35\"\n"
+            + "    platformBuildVersionName=\"15\">\n"
+            + "    <application android:label=\"" + label + "\" />\n"
+            + "</manifest>\n";
+    }
+
+    private static String getApktoolYml(String apkFileName, String usesLibrary) {
+        StringBuilder yml = new StringBuilder();
+        yml.append("version: 2.0.0\n");
+        yml.append("apkFileName: ").append(apkFileName).append('\n');
+        yml.append("usesFramework:\n");
+        yml.append("  ids:\n");
+        yml.append("  - 1\n");
+        if (usesLibrary != null) {
+            yml.append("usesLibrary:\n");
+            yml.append("- ").append(usesLibrary).append('\n');
+        }
+        yml.append("sdkInfo:\n");
+        yml.append("  minSdkVersion: 21\n");
+        yml.append("  targetSdkVersion: 35\n");
+        yml.append("resourcesInfo:\n");
+        yml.append("  packageId: 127\n");
+        yml.append("versionInfo:\n");
+        yml.append("  versionCode: 1\n");
+        yml.append("  versionName: 1.0\n");
+        return yml.toString();
+    }
+
+    private static String getLibraryDrawable() {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+            + "<shape xmlns:android=\"http://schemas.android.com/apk/res/android\" android:shape=\"rectangle\">\n"
+            + "    <size android:width=\"24dp\" android:height=\"24dp\" />\n"
+            + "    <solid android:color=\"#ff0000\" />\n"
+            + "</shape>\n";
+    }
+
+    private static String getMainDrawables() {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+            + "<resources>\n"
+            + "    <drawable name=\"alias_icon\">@drawable/lib_icon</drawable>\n"
+            + "</resources>\n";
+    }
+}

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/ResolveKeysMissingTypeSpecTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/ResolveKeysMissingTypeSpecTest.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (C) 2010 Ryszard Wiśniewski <brut.alll@gmail.com>
+ *  Copyright (C) 2010 Connor Tumbleson <connor.tumbleson@gmail.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package brut.androlib;
+
+import brut.androlib.meta.ApkInfo;
+import brut.androlib.res.table.ResId;
+import brut.androlib.res.table.ResPackage;
+import brut.androlib.res.table.ResTable;
+import brut.androlib.res.table.value.ResPrimitive;
+import brut.androlib.res.table.value.ResReference;
+import brut.androlib.res.table.value.ResStyle;
+import org.junit.Test;
+
+/**
+ * Regression tests: split APKs may reference types that are missing from their partial resource tables.
+ * We should not abort decoding when we can't inject dummy entry specs for those references.
+ */
+public class ResolveKeysMissingTypeSpecTest {
+    private static final int PKG_ID_APP = 0x7f;
+    private static final int TYPE_ID_MISSING = 0x04;
+
+    private static ResPackage newEmptyAppPackage(Config config) throws Exception {
+        ApkInfo apkInfo = new ApkInfo();
+        ResTable table = new ResTable(apkInfo, config);
+        return table.addPackageGroup(PKG_ID_APP, "app").getBasePackage();
+    }
+
+    @Test
+    public void styleResolveKeys_skipsMissingTypeSpec() throws Exception {
+        Config config = new Config("TEST");
+        ResPackage pkg = newEmptyAppPackage(config);
+
+        ResReference parent = new ResReference(pkg, ResId.of(PKG_ID_APP, 0x01, 0x0000));
+        ResReference key = new ResReference(pkg, ResId.of(PKG_ID_APP, TYPE_ID_MISSING, 0x0001));
+        ResStyle.Item item = new ResStyle.Item(key, ResPrimitive.FALSE);
+        ResStyle style = new ResStyle(parent, new ResStyle.Item[]{item});
+
+        style.resolveKeys();
+    }
+}

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/SplitAutoLibraryRoundTripTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/SplitAutoLibraryRoundTripTest.java
@@ -19,8 +19,14 @@ package brut.androlib;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Enumeration;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
 
 import static org.junit.Assert.assertTrue;
 
@@ -116,6 +122,53 @@ public class SplitAutoLibraryRoundTripTest extends BaseTest {
         assertTrue(publicXml.contains("name=\"SplitStyle\" id=\"0x7f1400e4\""));
     }
 
+    @Test
+    public void splitDecodeAutoPersistsSdkInfoNeededForAdaptiveIconRebuild() throws Exception {
+        File testDir = new File(sTmpDir, "split_auto_library_sdk_info");
+        File baseDir = new File(testDir, "base");
+        File splitDir = new File(testDir, "split");
+        File manifestOnlySplitDir = new File(testDir, "manifest-only-split");
+
+        writeFixtureFile(new File(baseDir, "AndroidManifest.xml"), getManifest("Base"));
+        writeFixtureFile(new File(baseDir, "apktool.yml"), getApktoolYml(BASE_APK_NAME, null, "26", "35"));
+        writeFixtureFile(new File(baseDir, "res/values/strings.xml"), getBaseStringsXml());
+
+        writeFixtureFile(new File(splitDir, "AndroidManifest.xml"), getManifest("Split"));
+        writeFixtureFile(new File(splitDir, "apktool.yml"), getApktoolYml(SPLIT_APK_NAME, null, "26", "35"));
+        writeFixtureFile(new File(splitDir, "res/mipmap-anydpi/ic_launcher.xml"), getAdaptiveIconXml());
+        writeFixtureFile(new File(splitDir, "res/drawable/ic_launcher_background.xml"), getAdaptiveBackgroundXml());
+        writeFixtureFile(new File(splitDir, "res/drawable/ic_launcher_foreground.xml"), getAdaptiveForegroundXml());
+
+        writeFixtureFile(new File(manifestOnlySplitDir, "AndroidManifest.xml"), getManifest("Split"));
+        writeFixtureFile(new File(manifestOnlySplitDir, "apktool.yml"), getApktoolYmlWithoutSdk(SPLIT_APK_NAME, null));
+        writeFixtureFile(new File(manifestOnlySplitDir, "res/values/strings.xml"), getBaseStringsXml());
+
+        File baseApk = new File(testDir, BASE_APK_NAME);
+        new ApkBuilder(baseDir, new Config("TEST")).build(baseApk);
+
+        File splitWithSdkApk = new File(testDir, "split-with-sdk.apk");
+        new ApkBuilder(splitDir, new Config("TEST")).build(splitWithSdkApk);
+
+        File splitWithoutSdkApk = new File(testDir, "split-without-sdk.apk");
+        new ApkBuilder(manifestOnlySplitDir, new Config("TEST")).build(splitWithoutSdkApk);
+
+        File splitApk = new File(testDir, SPLIT_APK_NAME);
+        replaceManifestEntry(splitWithSdkApk, splitWithoutSdkApk, splitApk);
+
+        File decodedSplitDir = new File(testDir, "decoded-split");
+        new ApkDecoder(splitApk, new Config("TEST")).decode(decodedSplitDir);
+
+        String apktoolYml = readTextFile(new File(decodedSplitDir, "apktool.yml"));
+        assertTrue(apktoolYml.contains("libraryFiles:"));
+        assertTrue(apktoolYml.contains("minSdkVersion: 26"));
+        assertTrue(apktoolYml.contains("targetSdkVersion: 35"));
+
+        File rebuiltSplitApk = new File(testDir, "rebuilt-split.apk");
+        new ApkBuilder(decodedSplitDir, new Config("TEST")).build(rebuiltSplitApk);
+
+        assertTrue(rebuiltSplitApk.isFile());
+    }
+
     private static void writeFixtureFile(File file, String contents) throws Exception {
         File parentDir = file.getParentFile();
         if (parentDir != null) {
@@ -143,6 +196,10 @@ public class SplitAutoLibraryRoundTripTest extends BaseTest {
     }
 
     private static String getApktoolYml(String apkFileName, String usesLibrary) {
+        return getApktoolYml(apkFileName, usesLibrary, "21", "35");
+    }
+
+    private static String getApktoolYml(String apkFileName, String usesLibrary, String minSdkVersion, String targetSdkVersion) {
         StringBuilder yml = new StringBuilder();
         yml.append("version: 2.0.0\n");
         yml.append("apkFileName: ").append(apkFileName).append('\n');
@@ -154,8 +211,28 @@ public class SplitAutoLibraryRoundTripTest extends BaseTest {
             yml.append("- ").append(usesLibrary).append('\n');
         }
         yml.append("sdkInfo:\n");
-        yml.append("  minSdkVersion: 21\n");
-        yml.append("  targetSdkVersion: 35\n");
+        yml.append("  minSdkVersion: ").append(minSdkVersion).append('\n');
+        yml.append("  targetSdkVersion: ").append(targetSdkVersion).append('\n');
+        yml.append("resourcesInfo:\n");
+        yml.append("  packageId: 127\n");
+        yml.append("  packageName: ").append(PACKAGE_NAME).append('\n');
+        yml.append("versionInfo:\n");
+        yml.append("  versionCode: 1\n");
+        yml.append("  versionName: 1.0\n");
+        return yml.toString();
+    }
+
+    private static String getApktoolYmlWithoutSdk(String apkFileName, String usesLibrary) {
+        StringBuilder yml = new StringBuilder();
+        yml.append("version: 2.0.0\n");
+        yml.append("apkFileName: ").append(apkFileName).append('\n');
+        yml.append("usesFramework:\n");
+        yml.append("  ids:\n");
+        yml.append("  - 1\n");
+        if (usesLibrary != null) {
+            yml.append("usesLibrary:\n");
+            yml.append("- ").append(usesLibrary).append('\n');
+        }
         yml.append("resourcesInfo:\n");
         yml.append("  packageId: 127\n");
         yml.append("  packageName: ").append(PACKAGE_NAME).append('\n');
@@ -196,6 +273,13 @@ public class SplitAutoLibraryRoundTripTest extends BaseTest {
             + "</resources>\n";
     }
 
+    private static String getBaseStringsXml() {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+            + "<resources>\n"
+            + "    <string name=\"app_name\">Split Test</string>\n"
+            + "</resources>\n";
+    }
+
     private static String getBaseAnimatorXml() {
         return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
             + "<selector xmlns:android=\"http://schemas.android.com/apk/res/android\">\n"
@@ -228,5 +312,62 @@ public class SplitAutoLibraryRoundTripTest extends BaseTest {
             + "        <item name=\"android:paddingLeft\">1dp</item>\n"
             + "    </style>\n"
             + "</resources>\n";
+    }
+
+    private static String getAdaptiveIconXml() {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+            + "<adaptive-icon xmlns:android=\"http://schemas.android.com/apk/res/android\">\n"
+            + "    <background android:drawable=\"@drawable/ic_launcher_background\" />\n"
+            + "    <foreground android:drawable=\"@drawable/ic_launcher_foreground\" />\n"
+            + "</adaptive-icon>\n";
+    }
+
+    private static String getAdaptiveBackgroundXml() {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+            + "<shape xmlns:android=\"http://schemas.android.com/apk/res/android\" android:shape=\"rectangle\">\n"
+            + "    <solid android:color=\"#FFFFFF\" />\n"
+            + "</shape>\n";
+    }
+
+    private static String getAdaptiveForegroundXml() {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+            + "<shape xmlns:android=\"http://schemas.android.com/apk/res/android\" android:shape=\"rectangle\">\n"
+            + "    <solid android:color=\"#000000\" />\n"
+            + "</shape>\n";
+    }
+
+    private static void replaceManifestEntry(File sourceApk, File manifestApk, File outApk) throws Exception {
+        byte[] manifestBytes = readZipEntry(manifestApk, "AndroidManifest.xml");
+
+        try (
+            ZipFile sourceZip = new ZipFile(sourceApk);
+            OutputStream fileOut = Files.newOutputStream(outApk.toPath());
+            ZipOutputStream zipOut = new ZipOutputStream(fileOut)
+        ) {
+            Enumeration<? extends ZipEntry> entries = sourceZip.entries();
+            while (entries.hasMoreElements()) {
+                ZipEntry entry = entries.nextElement();
+                ZipEntry outEntry = new ZipEntry(entry.getName());
+                zipOut.putNextEntry(outEntry);
+
+                if (entry.getName().equals("AndroidManifest.xml")) {
+                    zipOut.write(manifestBytes);
+                } else {
+                    try (InputStream in = sourceZip.getInputStream(entry)) {
+                        in.transferTo(zipOut);
+                    }
+                }
+                zipOut.closeEntry();
+            }
+        }
+    }
+
+    private static byte[] readZipEntry(File apkFile, String entryName) throws Exception {
+        try (ZipFile zipFile = new ZipFile(apkFile)) {
+            ZipEntry entry = zipFile.getEntry(entryName);
+            try (InputStream in = zipFile.getInputStream(entry)) {
+                return in.readAllBytes();
+            }
+        }
     }
 }

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/SplitAutoLibraryRoundTripTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/SplitAutoLibraryRoundTripTest.java
@@ -1,0 +1,232 @@
+/*
+ *  Copyright (C) 2010 Ryszard Wiśniewski <brut.alll@gmail.com>
+ *  Copyright (C) 2010 Connor Tumbleson <connor.tumbleson@gmail.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package brut.androlib;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertTrue;
+
+public class SplitAutoLibraryRoundTripTest extends BaseTest {
+    private static final String PACKAGE_NAME = "com.example.split";
+    private static final String BASE_APK_NAME = "base.apk";
+    private static final String SPLIT_APK_NAME = "config.xxhdpi.apk";
+
+    @Test
+    public void splitDecodeAutoPreservesDependentStyleAndStoresLibraryFile() throws Exception {
+        File testDir = new File(sTmpDir, "split_auto_library_roundtrip");
+        File baseDir = new File(testDir, "base");
+        File splitDir = new File(testDir, "split");
+
+        writeFixtureFile(new File(baseDir, "AndroidManifest.xml"), getManifest("Base"));
+        writeFixtureFile(new File(baseDir, "apktool.yml"), getApktoolYml(BASE_APK_NAME, null));
+        writeFixtureFile(new File(baseDir, "res/values/attrs.xml"), getBaseAttrsXml());
+        writeFixtureFile(new File(baseDir, "res/values/styles.xml"), getBaseStylesXml());
+
+        writeFixtureFile(new File(splitDir, "AndroidManifest.xml"), getManifest("Split"));
+        writeFixtureFile(new File(splitDir, "apktool.yml"), getApktoolYml(SPLIT_APK_NAME, PACKAGE_NAME));
+        writeFixtureFile(new File(splitDir, "res/values-hdpi/styles.xml"), getSplitStylesXml());
+
+        File baseApk = new File(testDir, BASE_APK_NAME);
+        new ApkBuilder(baseDir, new Config("TEST")).build(baseApk);
+
+        Config splitBuildConfig = new Config("TEST");
+        splitBuildConfig.setLibraryFiles(new String[] {
+            PACKAGE_NAME + ":" + baseApk.getAbsolutePath()
+        });
+
+        File splitApk = new File(testDir, SPLIT_APK_NAME);
+        new ApkBuilder(splitDir, splitBuildConfig).build(splitApk);
+
+        File decodedSplitDir = new File(testDir, "decoded-split");
+        new ApkDecoder(splitApk, new Config("TEST")).decode(decodedSplitDir);
+
+        assertTrue(new File(decodedSplitDir, "original/apktool-libs/" + PACKAGE_NAME + ".apk").isFile());
+
+        String decodedStylesXml = readStylesXml(decodedSplitDir);
+        assertTrue(decodedStylesXml.contains("<item name=\"barLength\">18.0dp</item>"));
+        assertTrue(decodedStylesXml.contains("<item name=\"drawableSize\">24.0dp</item>"));
+        assertTrue(decodedStylesXml.contains("<item name=\"gapBetweenBars\">3.0dp</item>"));
+
+        String apktoolYml = readTextFile(new File(decodedSplitDir, "apktool.yml"));
+        assertTrue(apktoolYml.contains("libraryFiles:"));
+        assertTrue(apktoolYml.contains("- " + PACKAGE_NAME + ":original/apktool-libs/" + PACKAGE_NAME + ".apk"));
+    }
+
+    @Test
+    public void splitRoundTripKeepsOriginalStyleIdWithAutoLibraryBuild() throws Exception {
+        File testDir = new File(sTmpDir, "split_auto_library_stable_ids");
+        File baseDir = new File(testDir, "base");
+        File splitDir = new File(testDir, "split");
+
+        writeFixtureFile(new File(baseDir, "AndroidManifest.xml"), getManifest("Base"));
+        writeFixtureFile(new File(baseDir, "apktool.yml"), getApktoolYml(BASE_APK_NAME, null));
+        writeFixtureFile(new File(baseDir, "res/values/public.xml"), getBasePublicXml());
+        writeFixtureFile(new File(baseDir, "res/values/styles.xml"), getBaseStableStylesXml());
+        writeFixtureFile(new File(baseDir, "res/animator/design_appbar_state_list_animator.xml"), getBaseAnimatorXml());
+
+        writeFixtureFile(new File(splitDir, "AndroidManifest.xml"), getManifest("Split"));
+        writeFixtureFile(new File(splitDir, "apktool.yml"), getApktoolYml(SPLIT_APK_NAME, PACKAGE_NAME));
+        writeFixtureFile(new File(splitDir, "res/values/public.xml"), getSplitPublicXml());
+        writeFixtureFile(new File(splitDir, "res/values-hdpi/styles.xml"), getSplitStableStylesXml());
+
+        File baseApk = new File(testDir, BASE_APK_NAME);
+        new ApkBuilder(baseDir, new Config("TEST")).build(baseApk);
+
+        Config splitBuildConfig = new Config("TEST");
+        splitBuildConfig.setLibraryFiles(new String[] {
+            PACKAGE_NAME + ":" + baseApk.getAbsolutePath()
+        });
+
+        File splitApk = new File(testDir, SPLIT_APK_NAME);
+        new ApkBuilder(splitDir, splitBuildConfig).build(splitApk);
+
+        File decodedSplitDir = new File(testDir, "decoded-split");
+        new ApkDecoder(splitApk, new Config("TEST")).decode(decodedSplitDir);
+
+        File rebuiltSplitApk = new File(testDir, "rebuilt-split.apk");
+        new ApkBuilder(decodedSplitDir, new Config("TEST")).build(rebuiltSplitApk);
+
+        Config redecodeConfig = new Config("TEST");
+        redecodeConfig.setLibraryFiles(new String[] {
+            PACKAGE_NAME + ":" + new File(decodedSplitDir, "original/apktool-libs/" + PACKAGE_NAME + ".apk").getAbsolutePath()
+        });
+
+        File redecodedSplitDir = new File(testDir, "redecoded-split");
+        new ApkDecoder(rebuiltSplitApk, redecodeConfig).decode(redecodedSplitDir);
+
+        String publicXml = readTextFile(new File(redecodedSplitDir, "res/values/public.xml"));
+        assertTrue(publicXml.contains("name=\"SplitStyle\" id=\"0x7f1400e4\""));
+    }
+
+    private static void writeFixtureFile(File file, String contents) throws Exception {
+        File parentDir = file.getParentFile();
+        if (parentDir != null) {
+            Files.createDirectories(parentDir.toPath());
+        }
+        Files.write(file.toPath(), contents.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String readStylesXml(File decodedDir) throws Exception {
+        File qualifiersFile = new File(decodedDir, "res/values-hdpi/styles.xml");
+        if (qualifiersFile.isFile()) {
+            return readTextFile(qualifiersFile);
+        }
+        return readTextFile(new File(decodedDir, "res/values/styles.xml"));
+    }
+
+    private static String getManifest(String label) {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+            + "<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\"\n"
+            + "    package=\"" + PACKAGE_NAME + "\"\n"
+            + "    platformBuildVersionCode=\"35\"\n"
+            + "    platformBuildVersionName=\"15\">\n"
+            + "    <application android:label=\"" + label + "\" />\n"
+            + "</manifest>\n";
+    }
+
+    private static String getApktoolYml(String apkFileName, String usesLibrary) {
+        StringBuilder yml = new StringBuilder();
+        yml.append("version: 2.0.0\n");
+        yml.append("apkFileName: ").append(apkFileName).append('\n');
+        yml.append("usesFramework:\n");
+        yml.append("  ids:\n");
+        yml.append("  - 1\n");
+        if (usesLibrary != null) {
+            yml.append("usesLibrary:\n");
+            yml.append("- ").append(usesLibrary).append('\n');
+        }
+        yml.append("sdkInfo:\n");
+        yml.append("  minSdkVersion: 21\n");
+        yml.append("  targetSdkVersion: 35\n");
+        yml.append("resourcesInfo:\n");
+        yml.append("  packageId: 127\n");
+        yml.append("  packageName: ").append(PACKAGE_NAME).append('\n');
+        yml.append("versionInfo:\n");
+        yml.append("  versionCode: 1\n");
+        yml.append("  versionName: 1.0\n");
+        return yml.toString();
+    }
+
+    private static String getBaseAttrsXml() {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+            + "<resources>\n"
+            + "    <attr name=\"barLength\" format=\"dimension\" />\n"
+            + "    <attr name=\"drawableSize\" format=\"dimension\" />\n"
+            + "    <attr name=\"gapBetweenBars\" format=\"dimension\" />\n"
+            + "</resources>\n";
+    }
+
+    private static String getBaseStylesXml() {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+            + "<resources>\n"
+            + "    <style name=\"Base.Widget.AppCompat.DrawerArrowToggle.Common\" parent=\"\" />\n"
+            + "</resources>\n";
+    }
+
+    private static String getBasePublicXml() {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+            + "<resources>\n"
+            + "    <public type=\"animator\" name=\"design_appbar_state_list_animator\" id=\"0x7f020000\" />\n"
+            + "    <public type=\"style\" name=\"BaseStyle\" id=\"0x7f140001\" />\n"
+            + "</resources>\n";
+    }
+
+    private static String getBaseStableStylesXml() {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+            + "<resources>\n"
+            + "    <style name=\"BaseStyle\" parent=\"\" />\n"
+            + "</resources>\n";
+    }
+
+    private static String getBaseAnimatorXml() {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+            + "<selector xmlns:android=\"http://schemas.android.com/apk/res/android\">\n"
+            + "    <item android:state_enabled=\"true\" android:animation=\"@android:anim/fade_in\" />\n"
+            + "</selector>\n";
+    }
+
+    private static String getSplitStylesXml() {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+            + "<resources>\n"
+            + "    <style name=\"Base.Widget.AppCompat.DrawerArrowToggle\" parent=\"@style/Base.Widget.AppCompat.DrawerArrowToggle.Common\">\n"
+            + "        <item name=\"barLength\">18.0dp</item>\n"
+            + "        <item name=\"drawableSize\">24.0dp</item>\n"
+            + "        <item name=\"gapBetweenBars\">3.0dp</item>\n"
+            + "    </style>\n"
+            + "</resources>\n";
+    }
+
+    private static String getSplitPublicXml() {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+            + "<resources>\n"
+            + "    <public type=\"style\" name=\"SplitStyle\" id=\"0x7f1400e4\" />\n"
+            + "</resources>\n";
+    }
+
+    private static String getSplitStableStylesXml() {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+            + "<resources>\n"
+            + "    <style name=\"SplitStyle\" parent=\"@style/BaseStyle\">\n"
+            + "        <item name=\"android:paddingLeft\">1dp</item>\n"
+            + "    </style>\n"
+            + "</resources>\n";
+    }
+}

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/SplitPackageDecodePreserveTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/SplitPackageDecodePreserveTest.java
@@ -1,0 +1,122 @@
+/*
+ *  Copyright (C) 2010 Ryszard Wiśniewski <brut.alll@gmail.com>
+ *  Copyright (C) 2010 Connor Tumbleson <connor.tumbleson@gmail.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package brut.androlib;
+
+import brut.androlib.meta.ApkInfo;
+import brut.androlib.res.ResDecoder;
+import brut.androlib.res.table.ResEntrySpec;
+import brut.androlib.res.table.ResId;
+import brut.androlib.res.table.ResPackage;
+import brut.androlib.res.table.ResPackageGroup;
+import brut.androlib.res.table.ResTable;
+import brut.androlib.res.table.value.ResPrimitive;
+import brut.androlib.res.table.value.ResReference;
+import brut.androlib.res.table.value.ResString;
+import brut.androlib.res.table.value.ResStyle;
+import brut.androlib.res.xml.ResXmlSerializer;
+import brut.directory.Directory;
+import brut.directory.FileDirectory;
+import org.junit.Test;
+
+import java.io.File;
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SplitPackageDecodePreserveTest extends BaseTest {
+    private static final int PKG_ID_APP = 0x7f;
+    private static final int TYPE_ID_STYLE = 0x02;
+    private static final int TYPE_ID_ATTR = 0x04;
+    private static final int TYPE_ID_STRING = 0x05;
+
+    private static final String SYNTHETIC_ATTR_NAME = ResEntrySpec.DUMMY_PREFIX + "0x7f040001";
+    private static final String SPLIT_DUMMY_STRING_NAME = ResEntrySpec.DUMMY_PREFIX + "0x7f050000";
+    private static final String SPLIT_REAL_STRING_NAME = "split_label";
+
+    @Test
+    public void decodeWithLibraries_keepsSamePackageSplitResourcesAndSkipsParserDummies() throws Exception {
+        Config config = new Config("TEST");
+        config.setLibraryFiles(new String[] {
+            "com.example.split:" + new File(sTmpDir, "config.xxhdpi.apk").getAbsolutePath()
+        });
+
+        ResDecoder decoder = new ResDecoder(new ApkInfo(), config);
+        ResTable table = decoder.getTable();
+
+        ResPackageGroup appGroup = table.addPackageGroup(PKG_ID_APP, "app");
+        ResPackage basePkg = appGroup.getBasePackage();
+        ResPackage splitPkg = appGroup.addSubPackage();
+
+        basePkg.addTypeSpec(TYPE_ID_STYLE, "style");
+        basePkg.addEntrySpec(TYPE_ID_STYLE, 0x0000, "MainMenuStyle");
+
+        splitPkg.addTypeSpec(TYPE_ID_ATTR, "attr");
+
+        basePkg.addTypeSpec(TYPE_ID_STRING, "string");
+        basePkg.addEntrySpec(TYPE_ID_STRING, 0x0000, "real_name");
+        basePkg.addEntry(TYPE_ID_STRING, 0x0000, new ResString("real"));
+
+        splitPkg.addTypeSpec(TYPE_ID_STRING, "string");
+        splitPkg.addEntrySpec(TYPE_ID_STRING, 0x0000, SPLIT_DUMMY_STRING_NAME);
+        splitPkg.addEntry(TYPE_ID_STRING, 0x0000, ResString.EMPTY);
+        splitPkg.addEntrySpec(TYPE_ID_STRING, 0x0001, SPLIT_REAL_STRING_NAME);
+        splitPkg.addEntry(TYPE_ID_STRING, 0x0001, new ResString("split"));
+
+        ResReference parent = new ResReference(basePkg, ResId.of(PKG_ID_APP, TYPE_ID_STYLE, 0x0001));
+        ResReference missingKey = new ResReference(basePkg, ResId.of(PKG_ID_APP, TYPE_ID_ATTR, 0x0001));
+        ResStyle style = new ResStyle(parent, new ResStyle.Item[] {
+            new ResStyle.Item(missingKey, ResPrimitive.FALSE)
+        });
+        basePkg.addEntry(TYPE_ID_STYLE, 0x0000, style);
+
+        style.resolveKeys();
+
+        File outDirFile = new File(sTmpDir, "split-preserve-" + System.nanoTime());
+        assertTrue(outDirFile.mkdirs());
+        Directory outDir = new FileDirectory(outDirFile);
+
+        invokeGenerator(decoder, "generateValuesXmls", basePkg, outDir, new ResXmlSerializer(false));
+
+        String attrsXml = readTextFile(new File(outDirFile, "res/values/attrs.xml"));
+        assertTrue(attrsXml.contains(SYNTHETIC_ATTR_NAME));
+
+        String stylesXml = readTextFile(new File(outDirFile, "res/values/styles.xml"));
+        assertTrue(stylesXml.contains(SYNTHETIC_ATTR_NAME));
+
+        String stringsXml = readTextFile(new File(outDirFile, "res/values/strings.xml"));
+        assertTrue(stringsXml.contains("real_name"));
+        assertTrue(stringsXml.contains(SPLIT_REAL_STRING_NAME));
+        assertFalse(stringsXml.contains(SPLIT_DUMMY_STRING_NAME));
+
+        invokeGenerator(decoder, "generatePublicXml", basePkg, outDir, new ResXmlSerializer(false));
+
+        String publicXml = readTextFile(new File(outDirFile, "res/values/public.xml"));
+        assertTrue(publicXml.contains("real_name"));
+        assertTrue(publicXml.contains(SPLIT_REAL_STRING_NAME));
+        assertTrue(publicXml.contains(SYNTHETIC_ATTR_NAME));
+        assertFalse(publicXml.contains(SPLIT_DUMMY_STRING_NAME));
+    }
+
+    private static void invokeGenerator(ResDecoder decoder, String methodName, ResPackage pkg, Directory outDir,
+            ResXmlSerializer serial) throws Exception {
+        Method method = ResDecoder.class.getDeclaredMethod(methodName, ResPackage.class, Directory.class,
+            ResXmlSerializer.class);
+        method.setAccessible(true);
+        method.invoke(decoder, pkg, outDir, serial);
+    }
+}


### PR DESCRIPTION
**Summary**
- Fixes `apktool d` failing on split APKs whose partial `resources.arsc` references a type ID that isn’t present in that split’s type specs (e.g. `UndefinedResObjectException`).

**What changed**
- `ResStyle.resolveKeys()` now skips injecting dummy entry specs when the referenced type spec is missing, instead of throwing and aborting decode.
- Adds a focused regression test: `brut.androlib.ResolveKeysMissingTypeSpecTest`.

**Repro / verification**
- Before: `apktool d config.hdpi.apk` can crash with `UndefinedResObjectException` during resource decode on some split APKs.
- After: decode completes; unresolved items are skipped (warnings may be logged).

**Testing**
- `.\gradlew.bat :brut.apktool:apktool-lib:test --tests brut.androlib.ResolveKeysMissingTypeSpecTest`
- `.\gradlew.bat :brut.apktool:apktool-cli:shadowJar`