### PR TITLE
Fix entry lookup performance in ResPackage

### DIFF
--- a/brut.apktool/apktool-lib/build.gradle.kts
+++ b/brut.apktool/apktool-lib/build.gradle.kts
@@ -8,7 +8,6 @@ dependencies {
     implementation(libs.baksmali)
     implementation(libs.smali)
     implementation(libs.guava)
-    implementation(libs.commons.lang3)
     implementation(libs.commons.io)
     implementation(libs.commons.text)
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/Framework.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/Framework.java
@@ -26,7 +26,7 @@ import brut.common.Log;
 import brut.util.BrutIO;
 import brut.util.OS;
 import brut.util.OSDetection;
-import org.apache.commons.lang3.tuple.Pair;
+import brut.util.Pair;
 
 import java.io.*;
 import java.nio.ByteBuffer;
@@ -127,8 +127,8 @@ public class Framework {
         // Publicize all entry specs.
         ByteBuffer buffer = ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN);
         for (Pair<Long, Integer> pair : parser.getEntrySpecFlagsOffsets()) {
-            int position = pair.getKey().intValue();
-            int count = pair.getValue();
+            int position = pair.getLeft().intValue();
+            int count = pair.getRight();
             for (int i = 0; i < count; i++, position += 4) {
                 int flags = buffer.getInt(position);
                 buffer.putInt(position, flags | 0x40000000); // ResTable_typeSpec::SPEC_PUBLIC

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/ResDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/ResDecoder.java
@@ -35,7 +35,7 @@ import brut.directory.Directory;
 import brut.directory.DirectoryException;
 import brut.directory.FileDirectory;
 import com.google.common.collect.Lists;
-import org.apache.commons.lang3.tuple.Pair;
+import brut.util.Pair;
 
 import java.io.*;
 import java.util.*;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/BinaryResourceParser.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/BinaryResourceParser.java
@@ -25,7 +25,7 @@ import brut.androlib.res.table.value.*;
 import brut.common.Log;
 import brut.util.BinaryDataInputStream;
 import com.google.common.io.BaseEncoding;
-import org.apache.commons.lang3.tuple.Pair;
+import brut.util.Pair;
 
 import java.io.BufferedInputStream;
 import java.io.InputStream;

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/ResPackage.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/ResPackage.java
@@ -19,7 +19,7 @@ package brut.androlib.res.table;
 import brut.androlib.exceptions.AndrolibException;
 import brut.androlib.exceptions.UndefinedResObjectException;
 import brut.androlib.res.table.value.ResValue;
-import org.apache.commons.lang3.tuple.Pair;
+import brut.util.Pair;
 
 import java.util.Collection;
 import java.util.HashMap;

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/DoubleExtensionUnknownFileTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/DoubleExtensionUnknownFileTest.java
@@ -17,7 +17,6 @@
 package brut.androlib;
 
 import brut.androlib.meta.ApkInfo;
-import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
 
@@ -40,9 +39,22 @@ public class DoubleExtensionUnknownFileTest extends BaseTest {
 
         ApkInfo testInfo = ApkInfo.load(testDir);
         for (String path : testInfo.getDoNotCompress()) {
-            if (StringUtils.countMatches(path, '.') > 1) {
+            if (countMatches(path, '.') > 1) {
                 assertTrue(path.equals("assets/bin/Data/sharedassets1.assets.split0"));
             }
         }
+    }
+
+    private int countMatches(final CharSequence str, final char ch) {
+        if (str == null || str.length() == 0)
+            return 0;
+
+        int count = 0;
+        for (int i = 0; i < str.length(); i++) {
+            if (ch == str.charAt(i)) {
+                count++;
+            }
+        }
+        return count;
     }
 }

--- a/brut.j.util/src/main/java/brut/util/Pair.java
+++ b/brut.j.util/src/main/java/brut/util/Pair.java
@@ -1,0 +1,48 @@
+package brut.util;
+
+import java.util.Objects;
+
+public final class Pair<L, R> {
+
+    private final L mLeft;
+    private final R mRight;
+
+    private Pair(L left, R right) {
+        mLeft = left;
+        mRight = right;
+    }
+
+    public static <A, B> Pair<A, B> of(A left, B right) {
+        return new Pair<>(left, right);
+    }
+
+    public L getLeft() {
+        return mLeft;
+    }
+
+    public R getRight() {
+        return mRight;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj instanceof Pair) {
+            Pair<?, ?> other = (Pair<?, ?>) obj;
+            return Objects.equals(mLeft, other.mLeft) && Objects.equals(mRight, other.mRight);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * Objects.hashCode(mLeft) + Objects.hashCode(mRight);
+    }
+
+    @Override
+    public String toString() {
+        return "(" + mLeft + ", " + mRight + ")";
+    }
+}

--- a/brut.j.util/src/main/java/brut/util/Pair.java
+++ b/brut.j.util/src/main/java/brut/util/Pair.java
@@ -7,13 +7,9 @@ public final class Pair<L, R> {
     private final L mLeft;
     private final R mRight;
 
-    private Pair(L left, R right) {
+    public Pair(L left, R right) {
         mLeft = left;
         mRight = right;
-    }
-
-    public static <A, B> Pair<A, B> of(A left, B right) {
-        return new Pair<>(left, right);
     }
 
     public L getLeft() {
@@ -22,6 +18,10 @@ public final class Pair<L, R> {
 
     public R getRight() {
         return mRight;
+    }
+
+    public static <A, B> Pair<A, B> of(A left, B right) {
+        return new Pair<>(left, right);
     }
 
     @Override

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,6 @@
 baksmali = "b6365a84f4" # https://github.com/google/smali/issues/100
 commons_io = "2.21.0"
 commons_cli = "1.11.0"
-commons_lang3 = "3.20.0"
 commons_text = "1.15.0"
 guava = "33.5.0-jre"
 junit = "4.13.2"
@@ -16,7 +15,6 @@ maven-publish = "0.33.0"
 baksmali = { module = "com.github.iBotPeaches.smali:smali-baksmali", version.ref = "baksmali" }
 commons_cli = { module = "commons-cli:commons-cli", version.ref = "commons_cli"}
 commons_io = { module = "commons-io:commons-io", version.ref = "commons_io" }
-commons_lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons_lang3" }
 commons_text = { module = "org.apache.commons:commons-text", version.ref = "commons_text" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 junit = { module = "junit:junit", version.ref = "junit" }


### PR DESCRIPTION
Previously, ResPackage used Apache's Pair implementation, which uses [XOR-based hashCode() generator](https://github.com/apache/commons-lang/blob/045d29e161cddaaa602db05dff23df6f20d2bd2c/src/main/java/org/apache/commons/lang3/tuple/Pair.java#L232-L235), which generates more collisions than standard `31 * fields` algorithm found in newer Java and Kotlin standard libraries. Apache's Pair conforms to Map.Entry, which explains why it uses XOR-based hash, but since ApkTool never treats Pair as Map.Entry, we can instead use a much better hash algorithm to prevent collisions.

I've also removed a dependency on Apache Commons lang3 since it was only ever used for Pair and StringUtils in one of the tests.

|Before|After|
|------|-----|
|<img width="706" height="387" alt="image" src="https://github.com/user-attachments/assets/82431941-59ad-4506-89c3-c1e82d4e37e2" />|<img width="705" height="381" alt="image" src="https://github.com/user-attachments/assets/30f34a45-bd4e-4d30-bc10-c9c6a1f1ce03" />|

This is way more noticeable in larger APKs. For example, the Samsung APK from my previous PR generates more than 200k HashMap entries. Such large HashMaps suffer the most from collisions.
<img width="605" height="180" alt="image" src="https://github.com/user-attachments/assets/8ebe8bd4-290f-42ca-abb4-cf38edd9bb0f" />