### PR TITLE
fix: support apk as library for split apks

### DIFF
--- a/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
+++ b/brut.apktool/apktool-cli/src/main/java/brut/apktool/Main.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.logging.*;
 
@@ -423,7 +424,13 @@ public class Main {
             config.setFrameworkTag(cli.getOptionValue(frameTagOption));
         }
         if (cli.hasOption(libOption)) {
-            config.setLibraryFiles(cli.getOptionValues(libOption));
+            Map<String, String[]> libraryFiles = config.getLibraryFiles();
+            for (String entry : cli.getOptionValues(libOption)) {
+                String[] parts = entry.split(":", 2);
+                if (parts.length == 2) {
+                    libraryFiles.put(parts[0], parts[1].split(","));
+                }
+            }
         }
         if (cli.hasOption(decodeForceOption)) {
             config.setForced(true);
@@ -545,7 +552,13 @@ public class Main {
             config.setFrameworkDirectory(cli.getOptionValue(frameDirOption));
         }
         if (cli.hasOption(libOption)) {
-            config.setLibraryFiles(cli.getOptionValues(libOption));
+            Map<String, String[]> libraryFiles = config.getLibraryFiles();
+            for (String entry : cli.getOptionValues(libOption)) {
+                String[] parts = entry.split(":", 2);
+                if (parts.length == 2) {
+                    libraryFiles.put(parts[0], parts[1].split(","));
+                }
+            }
         }
         if (cli.hasOption(buildForceOption)) {
             config.setForced(true);

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/Config.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/Config.java
@@ -16,6 +16,9 @@
  */
 package brut.androlib;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 public class Config {
     public enum DecodeSources { FULL, ONLY_MAIN_CLASSES, NONE }
     public enum DecodeResources { FULL, ONLY_MANIFEST, NONE }
@@ -28,7 +31,7 @@ public class Config {
     private int mJobs;
     private String mFrameworkDirectory;
     private String mFrameworkTag;
-    private String[] mLibraryFiles;
+    private final Map<String, String[]> mLibraryFiles;
     private boolean mForced;
     private boolean mVerbose;
 
@@ -57,7 +60,7 @@ public class Config {
         mJobs = Math.min(Runtime.getRuntime().availableProcessors(), 8);
         mFrameworkDirectory = null;
         mFrameworkTag = null;
-        mLibraryFiles = null;
+        mLibraryFiles = new LinkedHashMap<>();
         mForced = false;
         mVerbose = false;
 
@@ -110,12 +113,8 @@ public class Config {
         mFrameworkTag = frameworkTag;
     }
 
-    public String[] getLibraryFiles() {
+    public Map<String, String[]> getLibraryFiles() {
         return mLibraryFiles;
-    }
-
-    public void setLibraryFiles(String[] libraryFiles) {
-        mLibraryFiles = libraryFiles;
     }
 
     public boolean isForced() {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AaptInvoker.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/AaptInvoker.java
@@ -20,6 +20,7 @@ import brut.androlib.Config;
 import brut.androlib.exceptions.AndrolibException;
 import brut.androlib.meta.*;
 import brut.androlib.res.Framework;
+import brut.androlib.res.table.ResTable;
 import brut.common.BrutException;
 import brut.common.Log;
 import brut.util.OS;
@@ -127,10 +128,10 @@ public class AaptInvoker {
             int pkgId = resourcesInfo.getPackageId();
             if (pkgId == 0) {
                 cmd.add("--shared-lib");
-            } else if (pkgId > 1) {
+            } else if (pkgId > ResTable.SYS_PACKAGE_ID) {
                 cmd.add("--package-id");
                 cmd.add(Integer.toString(pkgId));
-                if (pkgId < 0x7F) {
+                if (pkgId < ResTable.APP_PACKAGE_ID) {
                     cmd.add("--allow-reserved-package-id");
                 }
             }
@@ -201,20 +202,13 @@ public class AaptInvoker {
 
         List<String> usesLibrary = mApkInfo.getUsesLibrary();
         if (!usesLibrary.isEmpty()) {
-            String[] libFiles = mConfig.getLibraryFiles();
+            Map<String, String[]> libraryFiles = mConfig.getLibraryFiles();
             for (String name : usesLibrary) {
-                File libFile = null;
-                if (libFiles != null) {
-                    for (String libEntry : libFiles) {
-                        String[] parts = libEntry.split(":", 2);
-                        if (parts.length == 2 && name.equals(parts[0])) {
-                            libFile = new File(parts[1]);
-                            break;
-                        }
+                String[] fileNames = libraryFiles.get(name);
+                if (fileNames != null) {
+                    for (String fileName : fileNames) {
+                        files.add(new File(fileName));
                     }
-                }
-                if (libFile != null) {
-                    files.add(libFile);
                 } else {
                     Log.w(TAG, "Shared library was not provided: " + name);
                 }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/ResDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/ResDecoder.java
@@ -92,14 +92,14 @@ public class ResDecoder {
         ResPackage pkg = mTable.getMainPackage();
 
         Log.i(TAG, "Decoding value resources...");
-        for (ResEntry entry : Lists.newArrayList(pkg.getGroup().listEntries())) {
+        for (ResEntry entry : Lists.newArrayList(listEntries(pkg))) {
             if (entry.getValue() instanceof ResBag) {
                 ((ResBag) entry.getValue()).resolveKeys();
             }
         }
 
         Log.i(TAG, "Decoding file resources...");
-        for (ResEntry entry : Lists.newArrayList(pkg.getGroup().listEntries())) {
+        for (ResEntry entry : Lists.newArrayList(listEntries(pkg))) {
             if (entry.getValue() instanceof ResFileReference) {
                 fileDecoder.decode(entry, inDir, outDir, mResFileMap);
             }
@@ -120,11 +120,15 @@ public class ResDecoder {
         }
     }
 
+    private static Iterable<ResEntry> listEntries(ResPackage pkg) {
+        return pkg.getId() == ResTable.SYS_PACKAGE_ID ? pkg.getGroup().listEntries() : pkg.listEntries();
+    }
+
     private void generateValuesXmls(ResPackage pkg, Directory outDir, ResXmlSerializer serial)
             throws AndrolibException {
         // Group entries by type name + qualifiers, ignoring alias duplicates in sub-packages.
         Map<Pair<String, String>, List<ResEntry>> entriesMap = new HashMap<>();
-        for (ResEntry entry : pkg.getGroup().listEntries()) {
+        for (ResEntry entry : listEntries(pkg)) {
             if (entry.getValue() instanceof ValuesXmlSerializable && !pkg.isAlias(entry.getResId())) {
                 ResType type = entry.getType();
                 Pair<String, String> key = Pair.of(type.getName(), type.getConfig().toQualifiers());
@@ -189,7 +193,7 @@ public class ResDecoder {
 
     private void generateStagingXmls(ResPackage pkg, Directory outDir, ResXmlSerializer serial)
             throws AndrolibException {
-        if (pkg.getGroup().getPackageCount() <= 1) {
+        if (pkg.getId() != ResTable.SYS_PACKAGE_ID) {
             return;
         }
 
@@ -197,6 +201,9 @@ public class ResDecoder {
         List<ResEntrySpec> subSpecs = new ArrayList<>();
         for (ResPackage subPkg : pkg.getGroup().listSubPackages()) {
             subSpecs.addAll(subPkg.listEntrySpecs());
+        }
+        if (subSpecs.isEmpty()) {
+            return;
         }
         subSpecs.sort(Comparator.comparing(ResEntrySpec::getResId));
 
@@ -347,7 +354,6 @@ public class ResDecoder {
 
             Log.i(TAG, "Decoding AndroidManifest.xml with " + (pkg != null ? "resources" : "only framework resources")
                      + "...");
-
             try (
                 InputStream in = inDir.getFileInput("AndroidManifest.xml");
                 OutputStream out = outDir.getFileOutput("AndroidManifest.xml")
@@ -437,7 +443,7 @@ public class ResDecoder {
                 List<String> usesLibrary = mApkInfo.getUsesLibrary();
                 libPackageIds.sort(null);
                 for (int id : libPackageIds) {
-                    usesLibrary.add(mTable.getDynamicRefPackageName(id));
+                    usesLibrary.add(id == pkg.getId() ? pkg.getName() : mTable.getDynamicRefPackageName(id));
                 }
             }
         } else {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/BinaryXmlResourceParser.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/BinaryXmlResourceParser.java
@@ -342,6 +342,12 @@ public class BinaryXmlResourceParser implements XmlPullParser {
                     return name;
                 }
 
+                Log.d(TAG, "Injecting dummy for unresolved attr reference: ns=%s, name=%s, id=%s",
+                    getAttributePrefix(index), name, nameId);
+                if (!pkg.hasTypeSpec(nameId.typeId())) {
+                    pkg.addTypeSpec(nameId.typeId(), "attr");
+                    pkg.addType(nameId.typeId(), ResConfig.DEFAULT);
+                }
                 if (name.isEmpty()) {
                     name = ResEntrySpec.DUMMY_PREFIX + nameId;
                 }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/BinaryXmlResourceParser.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/decoder/BinaryXmlResourceParser.java
@@ -332,7 +332,7 @@ public class BinaryXmlResourceParser implements XmlPullParser {
                 ResPackage pkg = mTable.getMainPackage();
                 if (pkg == null) {
                     // If no main package, we load "android" package instead.
-                    pkg = mTable.resolvePackageGroup(1).getBasePackage();
+                    pkg = mTable.resolvePackageGroup(ResTable.SYS_PACKAGE_ID).getBasePackage();
                 }
 
                 // #2836 - Skip item if the resource cannot be resolved.
@@ -415,7 +415,7 @@ public class BinaryXmlResourceParser implements XmlPullParser {
             ResPackage pkg = mTable.getMainPackage();
             if (pkg == null) {
                 // If no main package, we load "android" package instead.
-                pkg = mTable.resolvePackageGroup(1).getBasePackage();
+                pkg = mTable.resolvePackageGroup(ResTable.SYS_PACKAGE_ID).getBasePackage();
             }
 
             if (attr.valueType == ResValue.TYPE_STRING) {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/ResTable.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/ResTable.java
@@ -167,7 +167,9 @@ public class ResTable {
         if (id == 0 && mMainPackage != null) {
             id = getDynamicRefPackageId(name);
             if (id == 0) {
-                id = mNextPackageId++;
+                do {
+                    id = mNextPackageId++;
+                } while (mDynamicRefTable.containsKey(id));
             }
         }
 
@@ -185,36 +187,44 @@ public class ResTable {
     }
 
     public ResPackageGroup resolvePackageGroup(int id) throws AndrolibException {
-        ResPackageGroup pkgGroup = mPackageGroups.get(id);
-        if (pkgGroup == null) {
-            pkgGroup = loadLibraryById(id);
-            if (pkgGroup == null) {
-                pkgGroup = loadFrameworkById(id);
+        if (id != SYS_PACKAGE_ID && mMainPackage != null) {
+            ResPackageGroup pkgGroup = loadLibraryById(id);
+            if (pkgGroup != null) {
+                return pkgGroup;
             }
         }
-        return pkgGroup;
+
+        ResPackageGroup pkgGroup = mPackageGroups.get(id);
+        if (pkgGroup != null) {
+            return pkgGroup;
+        }
+
+        return loadFrameworkById(id);
     }
 
     private ResPackageGroup loadLibraryById(int id) throws AndrolibException {
-        String name = mDynamicRefTable.get(id);
-        String[] libFiles = mConfig.getLibraryFiles();
-        if (name == null || libFiles == null) {
-            return null;
+        if (mLibPackageIds.contains(id)) {
+            return mPackageGroups.get(id);
         }
 
-        File apkFile = null;
-        for (String libEntry : libFiles) {
-            String[] parts = libEntry.split(":", 2);
-            if (parts.length == 2 && name.equals(parts[0])) {
-                apkFile = new File(parts[1]);
-                break;
+        String name;
+        if (id == mMainPackage.getId()) {
+            name = mMainPackage.getName();
+        } else {
+            name = mDynamicRefTable.get(id);
+            if (name == null) {
+                return null;
             }
         }
-        if (apkFile == null) {
+
+        String[] fileNames = mConfig.getLibraryFiles().get(name);
+        if (fileNames == null) {
             return null;
         }
 
-        loadPackagesFromApk(apkFile);
+        for (String fileName : fileNames) {
+            loadPackagesFromApk(new File(fileName));
+        }
 
         ResPackageGroup pkgGroup = mPackageGroups.get(id);
         if (pkgGroup == null) {
@@ -226,8 +236,11 @@ public class ResTable {
     }
 
     private ResPackageGroup loadFrameworkById(int id) throws AndrolibException {
-        File apkFile = new Framework(mConfig).getApkFile(id);
-        loadPackagesFromApk(apkFile);
+        if (mFramePackageIds.contains(id)) {
+            return mPackageGroups.get(id);
+        }
+
+        loadPackagesFromApk(new Framework(mConfig).getApkFile(id));
 
         ResPackageGroup pkgGroup = mPackageGroups.get(id);
         if (pkgGroup == null) {
@@ -240,7 +253,6 @@ public class ResTable {
 
     private void loadPackagesFromApk(File apkFile) throws AndrolibException {
         Log.i(TAG, "Loading resource table from file: " + apkFile);
-
         try (ZipRODirectory zipDir = new ZipRODirectory(apkFile)) {
             loadPackagesFromApk(apkFile, zipDir, false);
         } catch (DirectoryException ex) {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResEnum.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResEnum.java
@@ -17,6 +17,7 @@
 package brut.androlib.res.table.value;
 
 import brut.androlib.exceptions.AndrolibException;
+import brut.androlib.res.table.ResConfig;
 import brut.androlib.res.table.ResEntry;
 import brut.androlib.res.table.ResEntrySpec;
 import brut.androlib.res.table.ResId;
@@ -58,10 +59,15 @@ public class ResEnum extends ResAttribute {
 
             // #2836 - Skip item if the resource cannot be resolved.
             if (skipUnresolved || keyId.pkgId() != pkg.getId()) {
-                Log.w(TAG, "Unresolved enum reference: key=%s, value=%s", key, symbol.getValue());
+                Log.w(TAG, "Unresolved enum symbol reference: " + key);
                 continue;
             }
 
+            Log.d(TAG, "Injecting dummy for unresolved enum symbol reference: " + key);
+            if (!pkg.hasTypeSpec(keyId.typeId())) {
+                pkg.addTypeSpec(keyId.typeId(), "id");
+                pkg.addType(keyId.typeId(), ResConfig.DEFAULT);
+            }
             pkg.addEntrySpec(keyId.typeId(), keyId.entryId(), ResEntrySpec.DUMMY_PREFIX + keyId);
             pkg.addEntry(keyId.typeId(), keyId.entryId(), ResCustom.ID);
         }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResFlags.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResFlags.java
@@ -17,6 +17,7 @@
 package brut.androlib.res.table.value;
 
 import brut.androlib.exceptions.AndrolibException;
+import brut.androlib.res.table.ResConfig;
 import brut.androlib.res.table.ResEntry;
 import brut.androlib.res.table.ResEntrySpec;
 import brut.androlib.res.table.ResId;
@@ -60,10 +61,15 @@ public class ResFlags extends ResAttribute {
 
             // #2836 - Skip item if the resource cannot be resolved.
             if (skipUnresolved || keyId.pkgId() != pkg.getId()) {
-                Log.w(TAG, "Unresolved flag reference: key=%s, value=%s", key, symbol.getValue());
+                Log.w(TAG, "Unresolved flag symbol reference: " + key);
                 continue;
             }
 
+            Log.d(TAG, "Injecting dummy for unresolved flag symbol reference: " + key);
+            if (!pkg.hasTypeSpec(keyId.typeId())) {
+                pkg.addTypeSpec(keyId.typeId(), "id");
+                pkg.addType(keyId.typeId(), ResConfig.DEFAULT);
+            }
             pkg.addEntrySpec(keyId.typeId(), keyId.entryId(), ResEntrySpec.DUMMY_PREFIX + keyId);
             pkg.addEntry(keyId.typeId(), keyId.entryId(), ResCustom.ID);
         }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResReference.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResReference.java
@@ -22,12 +22,15 @@ import brut.androlib.res.table.ResEntry;
 import brut.androlib.res.table.ResEntrySpec;
 import brut.androlib.res.table.ResId;
 import brut.androlib.res.table.ResPackage;
+import brut.common.Log;
 import org.xmlpull.v1.XmlSerializer;
 
 import java.io.IOException;
 import java.util.Objects;
 
 public class ResReference extends ResItem {
+    private static final String TAG = ResReference.class.getName();
+
     private final ResPackage mPackage;
     private final ResId mResId;
     private final boolean mAsAttr;
@@ -87,6 +90,9 @@ public class ResReference extends ResItem {
     public String toXmlTextValue() throws AndrolibException {
         ResEntrySpec spec = resolve();
         if (spec == null) {
+            if (mResId != ResId.NULL) {
+                Log.w(TAG, "Unresolved resource reference: " + this);
+            }
             // @null is a special primitive, not a true reference, but we have to fall back to it if we can't
             // resolve the reference.
             return "@null";

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResStyle.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResStyle.java
@@ -17,6 +17,7 @@
 package brut.androlib.res.table.value;
 
 import brut.androlib.exceptions.AndrolibException;
+import brut.androlib.res.table.ResConfig;
 import brut.androlib.res.table.ResEntry;
 import brut.androlib.res.table.ResEntrySpec;
 import brut.androlib.res.table.ResId;
@@ -92,10 +93,15 @@ public class ResStyle extends ResBag {
 
             // #2836 - Skip item if the resource cannot be resolved.
             if (skipUnresolved || keyId.pkgId() != pkg.getId()) {
-                Log.w(TAG, "Unresolved style reference: key=%s, value=%s", key, item.getValue());
+                Log.w(TAG, "Unresolved style item reference: " + key);
                 continue;
             }
 
+            Log.d(TAG, "Injecting dummy for unresolved style item reference: " + key);
+            if (!pkg.hasTypeSpec(keyId.typeId())) {
+                pkg.addTypeSpec(keyId.typeId(), "attr");
+                pkg.addType(keyId.typeId(), ResConfig.DEFAULT);
+            }
             pkg.addEntrySpec(keyId.typeId(), keyId.entryId(), ResEntrySpec.DUMMY_PREFIX + keyId);
             pkg.addEntry(keyId.typeId(), keyId.entryId(), ResAttribute.DEFAULT);
         }

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/SharedLibraryTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/SharedLibraryTest.java
@@ -30,22 +30,23 @@ public class SharedLibraryTest extends BaseTest {
 
     @Test
     public void isSharedResourceDecodingAndRebuildingWorking() throws Exception {
-        File libraryApk = new File(sTmpDir, "library.apk");
-        sConfig.getLibraryFiles().put("com.google.android.test.shared_library", new String[] { libraryApk.getAbsolutePath() });
-
         // decode library.apk
+        File libraryApk = new File(sTmpDir, "library.apk");
         File libraryDir = new File(libraryApk + ".out");
         new ApkDecoder(libraryApk, sConfig).decode(libraryDir);
-
-        // decode client.apk
-        File clientApk = new File(sTmpDir, "client.apk");
-        File clientDir = new File(clientApk + ".out");
-        new ApkDecoder(clientApk, sConfig).decode(clientDir);
 
         // build library.apk
         new ApkBuilder(libraryDir, sConfig).build(null);
 
         assertTrue(new File(libraryDir, "dist/" + libraryApk.getName()).exists());
+
+        // include library.apk as a shared library
+        sConfig.getLibraryFiles().put("com.google.android.test.shared_library", new String[] { libraryApk.getAbsolutePath() });
+
+        // decode client.apk
+        File clientApk = new File(sTmpDir, "client.apk");
+        File clientDir = new File(clientApk + ".out");
+        new ApkDecoder(clientApk, sConfig).decode(clientDir);
 
         // build client.apk
         new ApkBuilder(clientDir, sConfig).build(null);

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/SharedLibraryTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/SharedLibraryTest.java
@@ -22,8 +22,6 @@ import org.junit.*;
 import static org.junit.Assert.*;
 
 public class SharedLibraryTest extends BaseTest {
-    private static final String LIBRARY_APK = "library.apk";
-    private static final String CLIENT_APK = "client.apk";
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -32,17 +30,15 @@ public class SharedLibraryTest extends BaseTest {
 
     @Test
     public void isSharedResourceDecodingAndRebuildingWorking() throws Exception {
-        sConfig.setLibraryFiles(new String[] {
-            "com.google.android.test.shared_library:" + new File(sTmpDir, LIBRARY_APK).getAbsolutePath()
-        });
+        File libraryApk = new File(sTmpDir, "library.apk");
+        sConfig.getLibraryFiles().put("com.google.android.test.shared_library", new String[] { libraryApk.getAbsolutePath() });
 
         // decode library.apk
-        File libraryApk = new File(sTmpDir, LIBRARY_APK);
         File libraryDir = new File(libraryApk + ".out");
         new ApkDecoder(libraryApk, sConfig).decode(libraryDir);
 
         // decode client.apk
-        File clientApk = new File(sTmpDir, CLIENT_APK);
+        File clientApk = new File(sTmpDir, "client.apk");
         File clientDir = new File(clientApk + ".out");
         new ApkDecoder(clientApk, sConfig).decode(clientDir);
 


### PR DESCRIPTION
Support loading a base/config APK as a library for decoding split APKs.

Case study: https://www.apkmirror.com/apk/shopify-inc/arrive-package-tracker/shop-all-your-favorite-brands-2-248-1-release/shop-all-your-favorite-brands-2-248-1-android-apk-download/
In this instance, the base APK is cross-referenced with the DPI-specific config APKs, i.e. `base.apk` depends on any `split_config.*dpi.apk`, and every `split_config.*dpi.apk` depends on `base.apk`.

Decoding/building `base.apk` example:
```
apktool d --lib com.shopify.arrive:split_config.xxhdpi.apk base.apk -o out
cd out
apktool b --lib com.shopify.arrive:../split_config.xxhdpi.apk
```

Decoding/building `config.*dpi.apk` example:
```
apktool d --lib com.shopify.arrive:base.apk split_config.xxhdpi.apk -o out
cd out
apktool b --lib com.shopify.arrive:../base.apk
```

* Added the ability to specify multiple library APKs for the same package name, e.g.
`--lib com.shopify.arrive:split_config.de.apk,split_config.xxhdpi.apk`
It's rarely needed so I can't even find an example, but just in case it's ever needed.

Misc:
* Abolished crashing on missing type specs by injecting them along with the dummy specs (only common when decoding a split config APK without the base APK).
* Tweaked some loggings to be shorter.
* Added verbose-mode logging for dummy injection during resolution stage for debugging.
* Added warning for unresolved value references (as it's replaced with `@null`) as another indicator that a split APK has a dependency.

Tested on large scale. No changes in output.

closes: #4121
closes: #4122 