### PR TITLE
docs: link apktool-android for on-device aapt2 use

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ If you discover a security vulnerability within Apktool, please send an e-mail t
 - [Source (GitHub)](https://github.com/iBotPeaches/Apktool)
 - [Source (Bitbucket)](https://bitbucket.org/iBotPeaches/apktool/)
 
+### Android (in-app)
+
+For running decode/build **inside an Android app** with bundled **ARM/x86 `aapt2`**
+binaries, see the community-maintained
+[apktool-android](https://github.com/anirudhmalik/apktool-android) project. It is not
+part of this repository; use it for on-device workflows rather than the desktop CLI.
+
 
 ## Sponsors
 


### PR DESCRIPTION
## Summary
Adds a short link to [apktool-android](https://github.com/anirudhmalik/apktool-android) for users who want **on-device** decode/rebuild with bundled `aapt2` (see discussion in #2811).

## Scope
- Documentation only (`README.md`).
- No binary or build changes to core Apktool.

## Checklist
- [ ] Wording is neutral (community project, not bundled here).
- [ ] Placed in an existing “Links” / related-projects style section if possible.

Closes nothing unless a maintainer asks to close #2811 from docs; optional: “Related: #2811”.