### PR TITLE
chore: sanity check yaml + getters for ResConfig

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/meta/ApkInfo.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/meta/ApkInfo.java
@@ -104,6 +104,11 @@ public class ApkInfo implements YamlSerializable {
                 break;
             case "apkFileName":
                 mApkFileName = line.getValue();
+                // Sanity check for potential malicious input.
+                if (mApkFileName.equals(".") || mApkFileName.equals("..") || mApkFileName.indexOf('/') != -1
+                        || mApkFileName.indexOf('\\') != -1) {
+                    throw new SecurityException("Malicious value for apkFileName: " + mApkFileName);
+                }
                 break;
             case "usesFramework":
                 mUsesFramework.clear();

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/ResConfig.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/ResConfig.java
@@ -616,6 +616,106 @@ public class ResConfig {
         return sb.toString();
     }
 
+    public int getMcc() {
+        return mMcc;
+    }
+
+    public int getMnc() {
+        return mMnc;
+    }
+
+    public String getLanguage() {
+        return mLanguage;
+    }
+
+    public String getRegion() {
+        return mRegion;
+    }
+
+    public int getOrientation() {
+        return mOrientation;
+    }
+
+    public int getTouchscreen() {
+        return mTouchscreen;
+    }
+
+    public int getDensity() {
+        return mDensity;
+    }
+
+    public int getKeyboard() {
+        return mKeyboard;
+    }
+
+    public int getNavigation() {
+        return mNavigation;
+    }
+
+    public int getInputFlags() {
+        return mInputFlags;
+    }
+
+    public int getGrammaticalInflection() {
+        return mGrammaticalInflection;
+    }
+
+    public int getScreenWidth() {
+        return mScreenWidth;
+    }
+
+    public int getScreenHeight() {
+        return mScreenHeight;
+    }
+
+    public int getSdkVersion() {
+        return mSdkVersion;
+    }
+
+    public int getMinorVersion() {
+        return mMinorVersion;
+    }
+
+    public int getScreenLayout() {
+        return mScreenLayout;
+    }
+
+    public int getUiMode() {
+        return mUiMode;
+    }
+
+    public int getSmallestScreenWidthDp() {
+        return mSmallestScreenWidthDp;
+    }
+
+    public int getScreenWidthDp() {
+        return mScreenWidthDp;
+    }
+
+    public int getScreenHeightDp() {
+        return mScreenHeightDp;
+    }
+
+    public String getLocaleScript() {
+        return mLocaleScript;
+    }
+
+    public String getLocaleVariant() {
+        return mLocaleVariant;
+    }
+
+    public int getScreenLayout2() {
+        return mScreenLayout2;
+    }
+
+    public int getColorMode() {
+        return mColorMode;
+    }
+
+    public byte[] getUnknown() {
+        return mUnknown;
+    }
+
     public boolean isInvalid() {
         return mIsInvalid;
     }


### PR DESCRIPTION
Minor changes per user feedback:

* Basic sanity check for `apkFileName` for potential malicious injections in `apktool.yml`.
* Add getters for all `ResConfig` fields for projects that are using `apktool-lib` as a library. (Not used by the Apktool client and are stripped by R8.)