### PR TITLE
fix: support empty value for zero flags

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/StyledString.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/StyledString.java
@@ -98,5 +98,10 @@ public class StyledString implements CharSequence {
         public int getLastChar() {
             return mLastChar;
         }
+
+        @Override
+        public String toString() {
+            return String.format("Span{tag=%s, firstChar=%s, lastChar=%s}", mTag, mFirstChar, mLastChar);
+        }
     }
 }

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResAttribute.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResAttribute.java
@@ -146,6 +146,11 @@ public class ResAttribute extends ResBag {
         public ResPrimitive getValue() {
             return mValue;
         }
+
+        @Override
+        public String toString() {
+            return String.format("Symbol{key=%s, value=%s}", mKey, mValue);
+        }
     }
 
     public void addValueType(int valueType) {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResBag.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResBag.java
@@ -63,6 +63,11 @@ public abstract class ResBag extends ResValue implements ValuesXmlSerializable {
         public ResItem getValue() {
             return mValue;
         }
+
+        @Override
+        public String toString() {
+            return String.format("RawItem{key=0x%08x, value=%s}", mKey, mValue);
+        }
     }
 
     public void resolveKeys() throws AndrolibException {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResEnum.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResEnum.java
@@ -109,9 +109,13 @@ public class ResEnum extends ResAttribute {
             }
         }
 
+        // Stop early if the value is missing a symbol.
         if (symbolsCount == 0) {
-            symbols = null;
-        } else if (symbolsCount < symbols.length) {
+            mSymbolsCache.put(data, null);
+            return null;
+        }
+
+        if (symbolsCount < symbols.length) {
             symbols = Arrays.copyOf(symbols, symbolsCount);
         }
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResFlags.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResFlags.java
@@ -139,6 +139,12 @@ public class ResFlags extends ResAttribute {
                 }
             }
 
+            // Stop early if any of the flags are missing a symbol.
+            if (mask != data) {
+                mSymbolsCache.put(data, null);
+                return null;
+            }
+
             // Filter out redundant flags.
             if (symbolsCount > 2) {
                 Symbol[] filtered = new Symbol[symbolsCount];
@@ -170,9 +176,7 @@ public class ResFlags extends ResAttribute {
             }
         }
 
-        if (symbolsCount == 0) {
-            symbols = null;
-        } else if (symbolsCount < symbols.length) {
+        if (symbolsCount < symbols.length) {
             symbols = Arrays.copyOf(symbols, symbolsCount);
         }
 

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResStyle.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/table/value/ResStyle.java
@@ -76,6 +76,11 @@ public class ResStyle extends ResBag {
         public ResItem getValue() {
             return mValue;
         }
+
+        @Override
+        public String toString() {
+            return String.format("Item{key=%s, value=%s}", mKey, mValue);
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes: #4139

* Allows encoded `0x0` values in flags-type attributes to be rendered as empty values when there's no explicit symbol for `0x0`.
* Adds some `toString` implementations for more informative logging.