### PR TITLE
fix: force UTF8 on yaml parsing

### DIFF
--- a/brut.j.yaml/src/main/java/brut/yaml/YamlReader.java
+++ b/brut.j.yaml/src/main/java/brut/yaml/YamlReader.java
@@ -17,6 +17,7 @@
 package brut.yaml;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -39,7 +40,7 @@ public class YamlReader {
     }
 
     public void read(InputStream in) {
-        Scanner scanner = new Scanner(in);
+        Scanner scanner = new Scanner(in, StandardCharsets.UTF_8.name());
         mLines = new ArrayList<>();
         while (scanner.hasNextLine()) {
             mLines.add(new YamlLine(scanner.nextLine()));

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,6 +81,14 @@ subprojects {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
+    tasks.withType<JavaCompile>().configureEach {
+        options.encoding = "UTF-8"
+
+        if (JavaVersion.current().isJava9Compatible) {
+            options.release.set(8)
+        }
+    }
+
     val mavenProjects = arrayOf(
         "brut.j.common", "brut.j.util", "brut.j.dir", "brut.j.xml", "brut.j.yaml",
         "apktool-lib", "apktool-cli"
@@ -97,11 +105,4 @@ tasks.register("release") {
 
 tasks.wrapper {
     distributionType = Wrapper.DistributionType.ALL
-}
-
-tasks.withType<JavaCompile> {
-    options.compilerArgs.add("-Xlint:-options")
-    options.compilerArgs.add("--release 8")
-
-    options.encoding = "UTF-8"
 }


### PR DESCRIPTION
Our test suite forces UTF8, but userland did not. I experienced this in https://github.com/iBotPeaches/Apktool/pull/4175