### PR TITLE
fix: remove apktool-cli from maven publishing

### DIFF
--- a/brut.apktool/apktool-cli/build.gradle.kts
+++ b/brut.apktool/apktool-cli/build.gradle.kts
@@ -83,15 +83,3 @@ tasks.register<JavaExec>("proguard") {
         originalJar.get().toString()
     )
 }
-
-tasks.withType<org.gradle.api.publish.maven.tasks.PublishToMavenRepository> {
-    dependsOn(tasks.named("shadowJar"))
-}
-
-tasks.withType<org.gradle.plugins.signing.Sign> {
-    dependsOn(tasks.named("shadowJar"))
-}
-
-tasks.withType<org.gradle.api.publish.tasks.GenerateModuleMetadata> {
-    dependsOn(tasks.named("shadowJar"))
-}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -141,7 +141,7 @@ subprojects {
 
     val mavenProjects = arrayOf(
         "brut.j.common", "brut.j.util", "brut.j.dir", "brut.j.xml", "brut.j.yaml",
-        "apktool-lib", "apktool-cli"
+        "apktool-lib"
     )
 
     if (project.name in mavenProjects) {


### PR DESCRIPTION
This was requested a few years ago, but Maven enforces publishing limits and it doesn't make any sense to publish `-cli` as that is just a tiny bit of wrapper code from CLI -> library.

It'll be a breaking change, but folks shouldn't be using `-cli` in Maven.

<img width="1635" height="521" alt="Screenshot 2026-08-01 at 7 13 37 AM" src="https://github.com/user-attachments/assets/8143b3e2-2a52-496d-83cf-07e1b66b2dc2" />

