### PR TITLE
feat: allow outputting to empty folder without -f

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
@@ -27,10 +27,13 @@ import brut.directory.Directory;
 import brut.directory.DirectoryException;
 import brut.directory.ExtFile;
 import brut.util.BackgroundWorker;
+import brut.util.BrutIO;
 import brut.util.OS;
 import org.apache.commons.io.FilenameUtils;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
@@ -58,12 +61,24 @@ public class ApkDecoder {
     }
 
     public void decode(File outDir) throws AndrolibException {
-        if (!mConfig.isForced() && outDir.exists()) {
-            throw new OutDirExistsException(outDir.getPath());
-        }
         if (!mApkFile.isFile() || !mApkFile.canRead()) {
             throw new InFileNotFoundException(mApkFile.getPath());
         }
+        // We don't follow symlinks here for safety reasons.
+        boolean outExists = Files.exists(outDir.toPath(), LinkOption.NOFOLLOW_LINKS);
+        boolean outIsDirectory = Files.isDirectory(outDir.toPath(), LinkOption.NOFOLLOW_LINKS);
+        if (!mConfig.isForced() && outExists && (!outIsDirectory || BrutIO.isNonEmptyDirectory(outDir))) {
+            throw new OutDirExistsException(outDir.getPath());
+        }
+        if (outExists) {
+            if (outIsDirectory) {
+                OS.rmdir(outDir);
+            } else {
+                OS.rmfile(outDir);
+            }
+        }
+        OS.mkdir(outDir);
+
         if (mConfig.getJobs() > 1) {
             mWorker = new BackgroundWorker(mConfig.getJobs() - 1);
         }
@@ -73,9 +88,6 @@ public class ApkDecoder {
             mApkInfo.setApkFile(mApkFile);
             mSmaliDecoder = new SmaliDecoder(mApkFile, mConfig.isBaksmaliDebugMode());
             mResDecoder = new ResDecoder(mApkInfo, mConfig);
-
-            OS.rmdir(outDir);
-            OS.mkdir(outDir);
 
             Log.i(TAG, "Using Apktool " + mConfig.getVersion() + " on " + mApkFile.getName()
                      + (mWorker != null ? " with " + mConfig.getJobs() + " threads" : ""));

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
@@ -65,15 +65,16 @@ public class ApkDecoder {
             throw new InFileNotFoundException(mApkFile.getPath());
         }
         // We don't follow symlinks here for safety reasons.
-        boolean outExists = Files.exists(outDir.toPath(), LinkOption.NOFOLLOW_LINKS);
-        boolean outIsDirectory = Files.isDirectory(outDir.toPath(), LinkOption.NOFOLLOW_LINKS);
-        if (!mConfig.isForced() && outExists && (!outIsDirectory || BrutIO.isNonEmptyDirectory(outDir))) {
-            throw new OutDirExistsException(outDir.getPath());
-        }
-        if (outExists) {
-            if (outIsDirectory) {
+        if (Files.exists(outDir.toPath(), LinkOption.NOFOLLOW_LINKS)) {
+            if (Files.isDirectory(outDir.toPath(), LinkOption.NOFOLLOW_LINKS)) {
+                if (!mConfig.isForced() && BrutIO.isNonEmptyDirectory(outDir)) {
+                    throw new OutDirExistsException(outDir.getPath());
+                }
                 OS.rmdir(outDir);
             } else {
+                if (!mConfig.isForced()) {
+                    throw new OutDirExistsException(outDir.getPath());
+                }
                 OS.rmfile(outDir);
             }
         }

--- a/brut.j.util/src/main/java/brut/util/BrutIO.java
+++ b/brut.j.util/src/main/java/brut/util/BrutIO.java
@@ -22,6 +22,8 @@ import java.io.File;
 import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -47,6 +49,17 @@ public final class BrutIO {
         } finally {
             IOUtils.closeQuietly(in);
             IOUtils.closeQuietly(out);
+        }
+    }
+
+    public static boolean isNonEmptyDirectory(File file) {
+        if (!file.isDirectory()) {
+            return false;
+        }
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(file.toPath())) {
+            return stream.iterator().hasNext();
+        } catch (IOException ignored) {
+            return true;
         }
     }
 


### PR DESCRIPTION
Different approach for #4188 without compromising symlink safety.

Without `-f`/`--force` flag: Only accepts unused paths or empty real directories, otherwise fails.
With `-f`/`--force` flag: Removes existing directory or file. Symlink is removed like a file, without following it.

closes: #4188 