### PR TITLE
Fix crash encoding empty raw resource strings

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResStringEncoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResStringEncoder.java
@@ -161,6 +161,9 @@ public final class ResStringEncoder {
 
         StringBuilder out = new StringBuilder(len * 2);
         appendEscapedString(out, str, 0, len, attrType, false);
+        if (out.length() == 0) {
+            return "";
+        }
 
         // Raw strings might get encoded as typed values in edge cases. We skip this if the string has been quoted.
         if (out.charAt(0) != '"' && isAmbiguousString(out, attrType)) {

--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResStringEncoder.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResStringEncoder.java
@@ -161,12 +161,9 @@ public final class ResStringEncoder {
 
         StringBuilder out = new StringBuilder(len * 2);
         appendEscapedString(out, str, 0, len, attrType, false);
-        if (out.length() == 0) {
-            return "";
-        }
 
         // Raw strings might get encoded as typed values in edge cases. We skip this if the string has been quoted.
-        if (out.charAt(0) != '"' && isAmbiguousString(out, attrType)) {
+        if (out.length() > 0 && out.charAt(0) != '"' && isAmbiguousString(out, attrType)) {
             out.insert(0, '\\');
         }
 

--- a/brut.apktool/apktool-lib/src/test/java/brut/androlib/res/xml/EscapeXmlValueTest.java
+++ b/brut.apktool/apktool-lib/src/test/java/brut/androlib/res/xml/EscapeXmlValueTest.java
@@ -31,6 +31,7 @@ public class EscapeXmlValueTest extends BaseTest {
         assertEquals("foo&amp;bar", escape("foo&bar"));
         assertEquals("&lt;foo>", escape("<foo>"));
         assertEquals("&lt;![CDATA[foo]]&gt;", escape("<![CDATA[foo]]>"));
+        assertEquals("", escape("\u0000"));
     }
 
     private static String escape(String value) {


### PR DESCRIPTION
## What changed

- Guard raw string encoding after escaping when the output becomes empty.
- Add a regression test for a raw string containing only a trailing NUL (`0x00`).

## Why

`encodeRawString()` already returns early for empty input, but non-empty input can become empty after `appendEscapedString()` skips a trailing NUL (`0x00`) character. In that case the following `out.charAt(0)` throws `StringIndexOutOfBoundsException` while generating values XMLs.

This was reproduced while decoding a third-party APK that failed at:

```text
brut.androlib.res.xml.ResStringEncoder.encodeRawString
brut.androlib.res.xml.ResStringEncoder.encodeTextValue
brut.androlib.res.table.value.ResString.serializeToValuesXml
brut.androlib.res.ResDecoder.generateValuesXmls
```

Fixes #4210.

## Verification

- `./gradlew.bat :brut.apktool:apktool-lib:test --tests brut.androlib.res.xml.EscapeXmlValueTest`
- Built `:brut.apktool:apktool-cli:shadowJar` and verified the previously failing APK decodes resources successfully with `apktool d -f -s`.