### PR TITLE
chore: change gradle dist to gradle-bin

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=2
 retryBackOffMs=500


### PR DESCRIPTION
Android Studio projects normally use gradle-bin distributions rather than gradle-all.
No reason we shouldn't do the same and save up almost 70% of disk usage per distribution.
gradle-9.7.1-all: 517 MB unpacked
gradle-9.7.1-bin: 162 MB unpacked